### PR TITLE
Add link to WP-CLI Support. Edit text for clarity.

### DIFF
--- a/plugin-unit-tests.md
+++ b/plugin-unit-tests.md
@@ -7,8 +7,8 @@ category: Misc
 
 This guide will demonstrate how to:
 
-* set up unit tests for an existing plugin, using WP-CLI
-* run the tests locally
+* Set up unit tests for an existing plugin, using WP-CLI
+* Run the tests locally
 
 We're going to assume that you already have a plugin called `my-plugin`.
 
@@ -16,20 +16,21 @@ So, let's get started:
 
 1) [Install PHPUnit](https://github.com/sebastianbergmann/phpunit#installation) (5.x is only supported when running php7, phpunit 4.8 is required when running php5).
 
-2) Generate the plugin test files:
+2) Generate the plugin test files: 
 
-    wp scaffold plugin-tests my-plugin
+```bash
+wp scaffold plugin-tests my-plugin`
+```
 
 This command will generate all the files needed for running tests, including a `.travis.yml` file. If you host your plugin on Github and enable [Travis CI](http://about.travis-ci.org), the tests will be run automatically after every commit you make to the plugin.
 
-3) Initialize the testing environment locally:
+3) Initialize the testing environment locally: `cd` into the plugin directory and run the install script. (You'll need to already have `svn` and `wget` installed.)
 
-(you'll need to already have `svn` and `wget` available)
+```bash
+bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
+```
 
-    cd $(wp plugin path my-plugin --dir)
-    bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
-
-where:
+The install script first it installs a copy of WordPress in the `/tmp` directory (by default) as well as the WordPress unit testing tools. Then it creates a database to be used while running tests. The parameters that are passed to `install-wp-tests.sh` setup the test database.
 
 * `wordpress_test` is the name of the test database (**all data will be deleted!**)
 * `root` is the MySQL user name
@@ -37,12 +38,12 @@ where:
 * `localhost` is the MySQL server host
 * `latest` is the WordPress version; could also be `3.7`, `3.6.2` etc.
 
-This script does a couple things. First it installs a copy of WordPress in the `tmp/` directory (by default) as well as the WordPress unit testing tools. Then it creates a database to be used while running tests. 
+NOTE: This script can be run multiple times without errors, but it will *not* overwrite previously existing files. So if your DB credentials change, or you want to switch to a different instance of mysql, simply re-running the script won't be enough. You'll need to manually edit the `wp-config.php` that's installed in `/tmp`.
 
-NOTE: This script can be run multiple times without errors, but it will *not* overwrite previously existing files. So if your DB credentials change, or you want to switch to a different instance of mysql, simply re-running the script won't be enough. You'll need to manually edit the `wp-config.php` that's installed in the `tmp/`.
+4) Run the plugin tests: 
 
-4) Run the plugin tests:
+```bash
+phpunit
+```
 
-    phpunit
-
-**Note**: phpunit 4.8.x is required (5.x won't work)
+If you have trouble running the install script or phpunit, check [Support section](http://wp-cli.org/#support) for help and answers to common issues.


### PR DESCRIPTION
* Capitalize sentences in bullet points

* There was a note that `5.x is only supported when running php7, phpunit 4.8 is required when running php5` and `**Note**: phpunit 4.8.x is required (5.x won't work)` These seem confusing and a little contradictory so I removed the second note and kept the first which give better compatibility info
* Running the install script had 2 commands:
```
cd $(wp plugin path my-plugin --dir)
bash bin/install-wp-tests.sh wordpress_test root '' localhost latest
```
I specified that you need to be in the plugin directory and removed the `cd $(wp plugin path my-plugin --dir)` line. Although cool and interesting to use a sub shell command, it's a less known syntax and it was hard to understand what was going on. Seemed to break the rule of clarity over cleverness.

I also moved the explainer text around a little so it is easier to understand that we are explaining the parameters shown, not that you have to replace those (kinda generic looking params) with your own.

* For bash commands on their own line, I added the 3 ticks and specified bash so it will show proper color coding.

* Changed references for `tmp/` to `/tmp` to make it clearer that this is off the root directory.

* Added a note that if you have trouble, check out the WP-CLI Support section. This was the impetus for my edit. I had trouble running tests while using XAMPP. I was getting a "Can’t connect to the database" error and searching all around the internet for an answer. This (https://make.wordpress.org/cli/handbook/common-issues/) answer for using a custom PHP library solved it but wasn't easy to find. Since lots of people use MAMP or XAMPP, I considered how to include this information, but a link to this existing documentation is the best solution so the answer is maintained in a single place. Also, never hurts to point out where to get help.