### PR TITLE
Fix 404 links on Command Cookbook, also fixes #5

### DIFF
--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -15,11 +15,11 @@ Creating your own custom WP-CLI command can be easier than it looks — and you 
 
 ## Overview
 
-WP-CLI's goal is to offer a complete alternative to the WordPress admin; for any action you might want to perform in the WordPress admin, there should be an equivalent WP-CLI command. A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](/commands/plugin/install/)) is one such command, as is `wp plugin activate` ([doc](/commands/plugin/activate/)). Commands are useful to WordPress users because they can offer simple, precise interfaces for performing complex tasks.
+WP-CLI's goal is to offer a complete alternative to the WordPress admin; for any action you might want to perform in the WordPress admin, there should be an equivalent WP-CLI command. A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](/commands/plugin/install/)) is one such command, as is `wp plugin activate` ([doc](https://wp-cli.org/commands/plugin/activate/)). Commands are useful to WordPress users because they can offer simple, precise interfaces for performing complex tasks.
 
-_But_, the WordPress admin is a Swiss Army knife of infinite complexity. There's no way just this project could handle every use case. This is why WP-CLI includes a set of [common internal commands](/commands/), while also offering a [rich internal API](/docs/internal-api/) for third-parties to write and register their own commands.
+_But_, the WordPress admin is a Swiss Army knife of infinite complexity. There's no way just this project could handle every use case. This is why WP-CLI includes a set of [common internal commands](https://wp-cli.org/commands/), while also offering a [rich internal API](http://wp-cli.org/docs/internal-api/) for third-parties to write and register their own commands.
 
-WP-CLI commands can be [distributed as standalone packages](/package-index/), or bundled with WordPress plugins or themes. For the former, you can use `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)) to dynamically generate everything but the command itself.
+WP-CLI commands can be [distributed as standalone packages](https://wp-cli.org/package-index/), or bundled with WordPress plugins or themes. For the former, you can use `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)) to dynamically generate everything but the command itself.
 
 Packages are to WP-CLI as plugins are to WordPress. There are distinct differences in the approach you should take to creating a WP-CLI package.  While WP-CLI is an ever-growing alternative to /wp-admin it is important to note that you must first write your package to work with the WP-CLI internal API before considering how you work with WordPress APIs.
 
@@ -35,7 +35,7 @@ Third-party commands:
 
 * Can be defined in plugins or themes.
 * Can be easily scaffolded as standalone projects with `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)).
-* Can be distributed independent of a plugin or theme in the [Package Index](/package-index/).
+* Can be distributed independent of a plugin or theme in the [Package Index](http://wp-cli.org/package-index/).
 
 All commands:
 
@@ -43,7 +43,7 @@ All commands:
 
 ## Anatomy of a command
 
-WP-CLI supports registering any callable class, function, or closure as a command. `WP_CLI::add_command()` ([doc](/docs/internal-api/wp-cli-add-command/)) is used for both internal and third-party command registration.
+WP-CLI supports registering any callable class, function, or closure as a command. `WP_CLI::add_command()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-command/)) is used for both internal and third-party command registration.
 
 The **synopsis** of a command defines which **positional** and **associative** arguments a command accepts. Let's take a look at the synopsis for `wp plugin install`:
 
@@ -234,7 +234,7 @@ The longdesc is also displayed when calling the `help` command, for example, `wp
  * Hard-wrap option descriptions at **75 chars** after the colon and a space.
  * Hard-wrap everything else at **90 chars**.
 
-For more details on how you should format your command docs, please see WP-CLI's [documentation standards](/docs/documentation-standards/).
+For more details on how you should format your command docs, please see WP-CLI's [documentation standards](https://make.wordpress.org/cli/handbook/documentation-standards/).
 
 #### Docblock tags
 
@@ -289,7 +289,7 @@ Success: Hello, Joe!
 
 **@when**
 
-This is a special tag that tells WP-CLI when to execute the command. It supports [all registered WP-CLI hooks](/docs/internal-api/wp-cli-add-hook/).
+This is a special tag that tells WP-CLI when to execute the command. It supports [all registered WP-CLI hooks](http://wp-cli.org/docs/internal-api/wp-cli-add-hook/).
 
 ```
 @when after_wp_load
@@ -424,13 +424,13 @@ WP_CLI::add_command( 'find-unused-themes', $find_unused_themes_command, array(
 ) );
 ```
 
-Let's run through the [internal APIs](/docs/internal-api/) this command uses to achieve its goal:
+Let's run through the [internal APIs](http://wp-cli.org/docs/internal-api/) this command uses to achieve its goal:
 
-* `WP_CLI::add_command()` ([doc](/docs/internal-api/wp-cli-add-command/)) is used to register a `find-unused-themes` command to the `$find_unused_themes_command` closure. The `before_invoke` argument makes it possible to verify the command is running on a multisite install, and error if not.
-* `WP_CLI::error()` ([doc](/docs/internal-api/wp-cli-error/)) renders a nicely formatted error message and exits.
-* `WP_CLI::launch_self()` ([doc](/docs/internal-api/wp-cli-launch-self/)) initially spawns a process to get a list of all sites, then is later used to get the list of themes for a given site.
-* `WP_CLI::log()` ([doc](/docs/internal-api/wp-cli-log/)) renders informational output to the end user.
-* `WP_CLI\Utils\format_items()` ([doc](/docs/internal-api/wp-cli-utils-format-items/)) renders the list of unused themes after the command has completed its discovery.
+* `WP_CLI::add_command()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-add-command/)) is used to register a `find-unused-themes` command to the `$find_unused_themes_command` closure. The `before_invoke` argument makes it possible to verify the command is running on a multisite install, and error if not.
+* `WP_CLI::error()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-error/)) renders a nicely formatted error message and exits.
+* `WP_CLI::launch_self()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-launch-self/)) initially spawns a process to get a list of all sites, then is later used to get the list of themes for a given site.
+* `WP_CLI::log()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-log/)) renders informational output to the end user.
+* `WP_CLI\Utils\format_items()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-utils-format-items/)) renders the list of unused themes after the command has completed its discovery.
 
 ### Help rendering
 
@@ -493,7 +493,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	
 ### Add to the package index
 
-Standalone WP-CLI commands can be added to and installed from the [package index](/package-index/). The only technical requirement for being listed in the package index is to include a valid composer.json file with an autoload declaration. We recommended including `"type": "wp-cli-package"` to distinguish your project explicitly as a WP-CLI package.
+Standalone WP-CLI commands can be added to and installed from the [package index](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//package-index/). The only technical requirement for being listed in the package index is to include a valid composer.json file with an autoload declaration. We recommended including `"type": "wp-cli-package"` to distinguish your project explicitly as a WP-CLI package.
 
 Here's a full composer.json example from the server command:
 

--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -39,7 +39,7 @@ Third-party commands:
 
 All commands:
 
-* Follow the [documentation standards](/docs/documentation-standards/).
+* Follow the [documentation standards](https://make.wordpress.org/cli/handbook/documentation-standards/).
 
 ## Anatomy of a command
 

--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -15,7 +15,7 @@ Creating your own custom WP-CLI command can be easier than it looks — and you 
 
 ## Overview
 
-WP-CLI's goal is to offer a complete alternative to the WordPress admin; for any action you might want to perform in the WordPress admin, there should be an equivalent WP-CLI command. A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](/commands/plugin/install/)) is one such command, as is `wp plugin activate` ([doc](https://wp-cli.org/commands/plugin/activate/)). Commands are useful to WordPress users because they can offer simple, precise interfaces for performing complex tasks.
+WP-CLI's goal is to offer a complete alternative to the WordPress admin; for any action you might want to perform in the WordPress admin, there should be an equivalent WP-CLI command. A **command** is an atomic unit of WP-CLI functionality. `wp plugin install` ([doc](https://wp-cli.org/commands/plugin/install/)) is one such command, as is `wp plugin activate` ([doc](https://wp-cli.org/commands/plugin/activate/)). Commands are useful to WordPress users because they can offer simple, precise interfaces for performing complex tasks.
 
 _But_, the WordPress admin is a Swiss Army knife of infinite complexity. There's no way just this project could handle every use case. This is why WP-CLI includes a set of [common internal commands](https://wp-cli.org/commands/), while also offering a [rich internal API](http://wp-cli.org/docs/internal-api/) for third-parties to write and register their own commands.
 
@@ -426,11 +426,11 @@ WP_CLI::add_command( 'find-unused-themes', $find_unused_themes_command, array(
 
 Let's run through the [internal APIs](http://wp-cli.org/docs/internal-api/) this command uses to achieve its goal:
 
-* `WP_CLI::add_command()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-add-command/)) is used to register a `find-unused-themes` command to the `$find_unused_themes_command` closure. The `before_invoke` argument makes it possible to verify the command is running on a multisite install, and error if not.
-* `WP_CLI::error()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-error/)) renders a nicely formatted error message and exits.
-* `WP_CLI::launch_self()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-launch-self/)) initially spawns a process to get a list of all sites, then is later used to get the list of themes for a given site.
-* `WP_CLI::log()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-log/)) renders informational output to the end user.
-* `WP_CLI\Utils\format_items()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//docs/internal-api/wp-cli-utils-format-items/)) renders the list of unused themes after the command has completed its discovery.
+* `WP_CLI::add_command()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-add-command/)) is used to register a `find-unused-themes` command to the `$find_unused_themes_command` closure. The `before_invoke` argument makes it possible to verify the command is running on a multisite install, and error if not.
+* `WP_CLI::error()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-error/)) renders a nicely formatted error message and exits.
+* `WP_CLI::launch_self()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-launch-self/)) initially spawns a process to get a list of all sites, then is later used to get the list of themes for a given site.
+* `WP_CLI::log()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-log/)) renders informational output to the end user.
+* `WP_CLI\Utils\format_items()` ([doc](http://wp-cli.org/docs/internal-api/wp-cli-utils-format-items/)) renders the list of unused themes after the command has completed its discovery.
 
 ### Help rendering
 
@@ -493,7 +493,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	
 ### Add to the package index
 
-Standalone WP-CLI commands can be added to and installed from the [package index](http://wp-cli.org/docs/internal-api/wp-cli-add-hook//package-index/). The only technical requirement for being listed in the package index is to include a valid composer.json file with an autoload declaration. We recommended including `"type": "wp-cli-package"` to distinguish your project explicitly as a WP-CLI package.
+Standalone WP-CLI commands can be added to and installed from the [package index](http://wp-cli.org/package-index/). The only technical requirement for being listed in the package index is to include a valid composer.json file with an autoload declaration. We recommended including `"type": "wp-cli-package"` to distinguish your project explicitly as a WP-CLI package.
 
 Here's a full composer.json example from the server command:
 


### PR DESCRIPTION
For now I've linked all 404 pages back to the original .org site, this is at least until a more robust structure is put in place for handling sub-directories like was on the old site.