### PR TITLE
Remove tick (`) at end of scaffold command

### DIFF
--- a/plugin-unit-tests.md
+++ b/plugin-unit-tests.md
@@ -19,7 +19,7 @@ So, let's get started:
 2) Generate the plugin test files: 
 
 ```bash
-wp scaffold plugin-tests my-plugin`
+wp scaffold plugin-tests my-plugin
 ```
 
 This command will generate all the files needed for running tests, including a `.travis.yml` file. If you host your plugin on Github and enable [Travis CI](http://about.travis-ci.org), the tests will be run automatically after every commit you make to the plugin.


### PR DESCRIPTION
On the last edit I put the commands in triple tick code blocks, removing the `ticks`. However, it looks like I accidentally left a ` at the end of the scaffold command. This commit removes that.