### PR TITLE
Update directions for positional arguments

### DIFF
--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -201,7 +201,7 @@ The longdesc is middle part of the PHPDoc:
 
 Options defined in the longdesc are interpreted as the command's **synopsis**:
 
-* `<name>` is a required positional argument. Changing it to `<name>..` would mean the command could accept one or more positional arguments.
+* `<name>` is a required positional argument. Changing it to `<name>...` would mean the command could accept one or more positional arguments.
 * `[--type=<type>]` is an optional associative argument which defaults to 'success' and accepts either 'success' or 'error'. Changing it to `[--error]` would change the argument to behave as an optional boolean flag.
 
 *Note*: To accept arbitrary/unlimited number of optional associative arguments you would use the annotation `[--<field>=<value>]`.  So for example:


### PR DESCRIPTION
The description for the PHPDoc to declare positional arguments has a small mistake. It says that you add two periods `..` to an argument declaration to declare that one or more values will be accepted. It's actually three periods `...`. This updates the copy to fix that typo.

See, for instance, [wp plugin activate](https://github.com/wp-cli/wp-cli/blob/68f685acebb21fa4e51a000164bdc63d086b8bcf/php/commands/plugin.php#L227)