### PR TITLE
Fix copy-pasta error: --prompt s/b --dbpass (right?)

### DIFF
--- a/commands/config/create.md
+++ b/commands/config/create.md
@@ -69,7 +69,7 @@ default:
     Success: Generated 'wp-config.php' file.
 
     # Avoid disclosing password to bash history by reading from password.txt
-    $ wp core config --dbname=testing --dbuser=wp --prompt=dbpass < password.txt
+    $ wp core config --dbname=testing --dbuser=wp --dbpass=dbpass < password.txt
     Success: Generated 'wp-config.php' file.
 
 

--- a/commands/config/create.md
+++ b/commands/config/create.md
@@ -69,7 +69,8 @@ default:
     Success: Generated 'wp-config.php' file.
 
     # Avoid disclosing password to bash history by reading from password.txt
-    $ wp core config --dbname=testing --dbuser=wp --dbpass=dbpass < password.txt
+    # Using --prompt=dbpass will prompt for the 'dbpass' argument
+    $ wp core config --dbname=testing --dbuser=wp --prompt=dbpass < password.txt
     Success: Generated 'wp-config.php' file.
 
 


### PR DESCRIPTION
Best I can tell, the example should have had `--dbpass` instead of `--prompt`?