### PR TITLE
Load WP utils in order to generate docs for `wp_clear_object_cache()`

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -219,6 +219,7 @@ EOT;
 	 */
 	public function api_dump() {
 		$apis = array();
+		require WP_CLI_ROOT . '/php/utils-wp.php';
 		$functions = get_defined_functions();
 		foreach( $functions['user'] as $function ) {
 			$reflection = new \ReflectionFunction( $function );

--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -323,6 +323,12 @@
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/master\/internal-api\/wp-cli-utils-report-batch-operation-results.md",
         "parent": "internal-api"
     },
+    "wp-cli-utils-wp-clear-object-cache": {
+        "title": "WP_CLI\\Utils\\wp_clear_object_cache()",
+        "slug": "wp-cli-utils-wp-clear-object-cache",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/master\/internal-api\/wp-cli-utils-wp-clear-object-cache.md",
+        "parent": "internal-api"
+    },
     "wp-cli-utils-write-csv": {
         "title": "WP_CLI\\Utils\\write_csv()",
         "slug": "wp-cli-utils-write-csv",

--- a/internal-api.md
+++ b/internal-api.md
@@ -125,6 +125,9 @@ This also means functions and methods not listed here are considered part of the
 <li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the system's temp directory. Warns user if it isn't writable.</li>
 
 
+<li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-utils-wp-clear-object-cache/">WP_CLI\Utils\wp_clear_object_cache()</a></strong> - Clear WordPress internal object caches.</li>
+
+
 <li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-get-php-binary/">WP_CLI::get_php_binary()</a></strong> - Get the path to the PHP binary used when executing WP-CLI.</li>
 
 

--- a/internal-api/wp-cli-get-php-binary.md
+++ b/internal-api/wp-cli-get-php-binary.md
@@ -34,6 +34,9 @@ Environment values permit specific binaries to be indicated.
 <li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the system's temp directory. Warns user if it isn't writable.</li>
 
 
+<li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-utils-wp-clear-object-cache/">WP_CLI\Utils\wp_clear_object_cache()</a></strong> - Clear WordPress internal object caches.</li>
+
+
 
 </ul>
 

--- a/internal-api/wp-cli-utils-wp-clear-object-cache.md
+++ b/internal-api/wp-cli-utils-wp-clear-object-cache.md
@@ -1,0 +1,47 @@
+# WP_CLI\Utils\wp_clear_object_cache()
+
+Clear WordPress internal object caches.
+
+***
+
+## Usage
+
+    WP_CLI\Utils\wp_clear_object_cache()
+
+<div>
+</div>
+
+
+***
+
+## Notes
+
+In long-running scripts, the internal caches on `$wp_object_cache` and `$wpdb`
+can grow to consume gigabytes of memory. Periodically calling this utility
+can help with memory management.
+
+
+*Internal API documentation is generated from the WP-CLI codebase on every release. To suggest improvements, please submit a pull request.*
+
+
+***
+
+## Related
+
+<ul>
+
+
+
+<li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-utils-get-home-dir/">WP_CLI\Utils\get_home_dir()</a></strong> - Get the home directory.</li>
+
+
+<li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-utils-get-temp-dir/">WP_CLI\Utils\get_temp_dir()</a></strong> - Get the system's temp directory. Warns user if it isn't writable.</li>
+
+
+<li><strong><a href="https://make.wordpress.org/cli/handbook/internal-api/wp-cli-get-php-binary/">WP_CLI::get_php_binary()</a></strong> - Get the path to the PHP binary used when executing WP-CLI.</li>
+
+
+
+</ul>
+
+


### PR DESCRIPTION
Fixes #78