### PR TITLE
Only list global parameters when a command doesn't have subcommands

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -316,7 +316,12 @@ See [global parameter documentation](https://make.wordpress.org/cli/handbook/con
 EOT;
 
 			// Replace Global parameters with a nice table
-			$docs = preg_replace( '/(#?## GLOBAL PARAMETERS).+/s', '$1' . PHP_EOL . PHP_EOL . $global_parameters, $docs );
+			if ( $binding['has-subcommands'] ) {
+				$replace_global = '';
+			} else {
+				$replace_global = '$1' . PHP_EOL . PHP_EOL . $global_parameters;
+			}
+			$docs = preg_replace( '/(#?## GLOBAL PARAMETERS).+/s', $replace_global, $docs );
 
 			$binding['docs'] = $docs;
 		}

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -14,20 +14,4 @@ Use a persistent object cache drop-in to persist cache values between requests.
     $ wp cache get my_key my_group
     my_value
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/cap.md
+++ b/commands/cap.md
@@ -16,20 +16,4 @@ Manage user capabilities.
     $ wp cap list 'author' | xargs wp cap remove 'editor'
     Success: Removed 34 capabilities from 'editor' role.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/checksum.md
+++ b/commands/checksum.md
@@ -4,20 +4,4 @@ Verify WordPress core checksums.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/cli.md
+++ b/commands/cli.md
@@ -19,20 +19,4 @@ Review current WP-CLI info, check for updates, or see defined aliases.
     New version works. Proceeding to replace.
     Success: Updated WP-CLI to 0.24.1.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/comment.md
+++ b/commands/comment.md
@@ -21,20 +21,4 @@ Manage comments.
     Success: Deleted comment 264.
     Success: Deleted comment 262.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/comment/meta.md
+++ b/commands/comment/meta.md
@@ -22,20 +22,4 @@ Manage comment custom fields.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/config.md
+++ b/commands/config.md
@@ -4,20 +4,4 @@ Manage the wp-config.php file
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/core.md
+++ b/commands/core.md
@@ -18,20 +18,4 @@ Download, install, update and manage a WordPress install.
     $ wp core version
     4.5.2
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/cron.md
+++ b/commands/cron.md
@@ -8,20 +8,4 @@ Manage WP-Cron events and schedules.
     $ wp cron test
     Success: WP-Cron spawning is working as expected.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/cron/event.md
+++ b/commands/cron/event.md
@@ -22,20 +22,4 @@ Manage WP-Cron events.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/cron/schedule.md
+++ b/commands/cron/schedule.md
@@ -16,20 +16,4 @@ Manage WP-Cron schedules.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/db.md
+++ b/commands/db.md
@@ -19,20 +19,4 @@ Perform basic database operations using credentials stored in wp-config.php
     # Execute a SQL query stored in a file.
     $ wp db query < debug.sql
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/language.md
+++ b/commands/language.md
@@ -4,20 +4,4 @@
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/language/core.md
+++ b/commands/language/core.md
@@ -26,20 +26,4 @@ Manage core language.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/media.md
+++ b/commands/media.md
@@ -16,20 +16,4 @@ Import new attachments or regenerate existing ones.
     $ wp media import ~/Downloads/image.png --post_id=123 --title="A downloaded picture" --featured_image
     Success: Imported file '/home/person/Downloads/image.png' as attachment ID 1753 and attached to post 123 as featured image.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/menu.md
+++ b/commands/menu.md
@@ -25,20 +25,4 @@ List, create, assign, and delete menus.
     $ wp menu location assign my-menu primary
     Success: Assigned location to menu.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/menu/item.md
+++ b/commands/menu/item.md
@@ -18,20 +18,4 @@ List, add, and delete items associated with a menu.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/menu/location.md
+++ b/commands/menu/location.md
@@ -23,20 +23,4 @@ Manage a menu's assignment to locations.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/network.md
+++ b/commands/network.md
@@ -4,20 +4,4 @@
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/network/meta.md
+++ b/commands/network/meta.md
@@ -12,20 +12,4 @@ Manage network custom fields.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/option.md
+++ b/commands/option.md
@@ -20,20 +20,4 @@ Manage options.
     $ wp option delete my_option
     Success: Deleted 'my_option' option.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/package.md
+++ b/commands/package.md
@@ -46,20 +46,4 @@ Learn how to create your own command from the
     Regenerating Composer autoload.
     Success: Uninstalled package.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/plugin.md
+++ b/commands/plugin.md
@@ -31,20 +31,4 @@ Manage plugins.
     Plugin 'bbpress' activated.
     Success: Installed 1 of 1 plugins.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/post-type.md
+++ b/commands/post-type.md
@@ -19,20 +19,4 @@ Manage post types.
     | nav_menu_item |        |
     +---------------+--------+
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/post.md
+++ b/commands/post.md
@@ -16,20 +16,4 @@ Manage posts.
     $ wp post delete 123
     Success: Trashed post 123.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/post/meta.md
+++ b/commands/post/meta.md
@@ -22,20 +22,4 @@ Manage post custom fields.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/post/term.md
+++ b/commands/post/term.md
@@ -10,20 +10,4 @@ Manage post terms.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/rewrite.md
+++ b/commands/rewrite.md
@@ -21,20 +21,4 @@ Manage rewrite rules.
     category/(.+?)/(feed|rdf|rss|rss2|atom)/?$,index.php?category_name=$matches[1]&amp;feed=$matches[2],category
     category/(.+?)/embed/?$,index.php?category_name=$matches[1]&amp;embed=true,category
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/role.md
+++ b/commands/role.md
@@ -29,20 +29,4 @@ Manage user roles.
     $ wp role reset administrator author contributor
     Success: Reset 3/3 roles.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -17,20 +17,4 @@ Generate code for post types, taxonomies, plugins, child themes, etc.
     $ wp scaffold post-type movie --label=Movie --theme=simple-life
     Success: Created /var/www/example.com/public_html/wp-content/themes/simple-life/post-types/movie.php
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/sidebar.md
+++ b/commands/sidebar.md
@@ -10,20 +10,4 @@ Manage sidebars.
     "Widget Area",sidebar-1
     "Inactive Widgets",wp_inactive_widgets
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/site.md
+++ b/commands/site.md
@@ -18,20 +18,4 @@ Perform site-wide operations.
     Are you sure you want to delete the 'http://www.example.com/example' site? [y/n] y
     Success: The site at 'http://www.example.com/example' was deleted.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/site/option.md
+++ b/commands/site/option.md
@@ -22,20 +22,4 @@ Manage site options in a multisite install.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/super-admin.md
+++ b/commands/super-admin.md
@@ -17,20 +17,4 @@ Manage super admins on WordPress multisite.
     $ wp super-admin remove superadmin2
     Success: Revoked super-admin capabilities.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/taxonomy.md
+++ b/commands/taxonomy.md
@@ -18,20 +18,4 @@ Manage taxonomies.
     $ wp taxonomy get post_tag --field=cap
     {"manage_terms":"manage_categories","edit_terms":"manage_categories","delete_terms":"manage_categories","assign_terms":"edit_posts"}
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/term.md
+++ b/commands/term.md
@@ -29,20 +29,4 @@ Manage terms.
     Success: Updated category term count
     Success: Updated post_tag term count
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/term/meta.md
+++ b/commands/term/meta.md
@@ -22,20 +22,4 @@ Manage term custom fields.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/theme.md
+++ b/commands/theme.md
@@ -32,20 +32,4 @@ Manage themes.
     		Version: 1.2
     		Author: the WordPress team
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/theme/mod.md
+++ b/commands/theme/mod.md
@@ -18,20 +18,4 @@ Manage theme mods.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/transient.md
+++ b/commands/transient.md
@@ -24,20 +24,4 @@ Manage transients.
     $ wp transient delete --all
     Success: 14 transients deleted from the database.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/user.md
+++ b/commands/user.md
@@ -21,20 +21,4 @@ Manage users.
     $ wp user delete 123 --reassign=567
     Success: Removed user 123 from http://example.com
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/user/meta.md
+++ b/commands/user/meta.md
@@ -28,20 +28,4 @@ Manage user custom fields.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/user/session.md
+++ b/commands/user/session.md
@@ -15,20 +15,4 @@ Manage a user's sessions.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/user/term.md
+++ b/commands/user/term.md
@@ -10,20 +10,4 @@ Manage user terms.
 
 
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 

--- a/commands/widget.md
+++ b/commands/widget.md
@@ -25,20 +25,4 @@ Manage sidebar widgets.
     $ wp widget delete calendar-2 archive-1
     Success: 2 widgets removed from sidebar.
 
-### GLOBAL PARAMETERS
-
-WP-CLI has a [series of global parameters](https://make.wordpress.org/cli/handbook/config/) that work with all commands. They are called _global parameters_ because they affect how WP-CLI interacts with WordPress and have the same behavior across all commands.
-
-Common global parameters include:
-
-| **Argument**    | **Description**              |
-|:----------------|:-----------------------------|
-| `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>`   | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
-| `--user=<user>` | Set the WordPress user.      |
-| `--require=<path>` | Load PHP file before running the command (may be used more than once). |
-| `--skip-plugins[=<plugin>]` | Skip loading all or some plugins. Note: mu-plugins are still loaded. |
-| `--skip-themes[=<theme>]` | Skip loading all or some themes. |
-
-See [global parameter documentation](https://make.wordpress.org/cli/handbook/config/) for the full list and other configuration options.
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/4244