### PR TITLE
Clarifying optional argument logic.

### DIFF
--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -204,7 +204,7 @@ The longdesc is middle part of the PHPDoc:
 Options defined in the longdesc are interpreted as the command's **synopsis**:
 
 * `<name>` is a required positional argument. Changing it to `<name>...` would mean the command could accept one or more positional arguments.
-* `[--type=<type>]` is an optional associative argument which defaults to 'success' and accepts either 'success' or 'error'. Changing it to `[--error]` would change the argument to behave as an optional boolean flag.
+* `[--type=<type>]` is an optional associative argument which defaults to 'success' and accepts either 'success' or 'error'. Changing it to `[--error]` would change the argument to behave as an optional boolean flag. A default value is required for optional arguments (for boolean arguments this would be `true`, `yes`, `1`, `false`, `no`, or `0`).
 
 *Note*: To accept arbitrary/unlimited number of optional associative arguments you would use the annotation `[--<field>=<value>]`.  So for example:
 


### PR DESCRIPTION
I was thrown by this for a little while and think some additional language clarifies how `default` works. If you omit `default` the parser won't complain, but it won't recognize the argument.