### PR TITLE
Added note for checksum command

### DIFF
--- a/commands/checksum.md
+++ b/commands/checksum.md
@@ -2,6 +2,6 @@
 
 Verify WordPress core checksums.
 
+### NOTE
 
-
-
+If you experience failure from this command, please try to specify the `--locale` and `--version` arguments.


### PR DESCRIPTION
I noticed today that the checksum command was saying we had modified core files on a client site. Knowing the client lacked the technical capacity to perform edits, and hoping nobody from my business had performed edits I looked into the commands, tried the locale and it worked. Most of our clients are en_US default locale which is why it's never been encountered before, but I feel the documentation could assist users getting to know wp-cli.