### PR TITLE
Improve command descriptions

### DIFF
--- a/commands/cache.md
+++ b/commands/cache.md
@@ -4,7 +4,7 @@ Manipulates the WP Object Cache.
 
 Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache) drop-in to persist cache values between requests.
 
-### EXAMPLES
+### Examples
 
     # Set cache.
     $ wp cache set my_key my_value my_group 300

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -6,23 +6,22 @@ Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_O
 
 ### Examples
 
-`
+    # Set cache.
+    $ wp cache set my_key my_value my_group 300
+    Success: Set object 'my_key' in group 'my_group'.
+   
+    # Get cache.
+    $ wp cache get my_key my_group
+    my_value
+
+
+### Examples
+
     # Set cache.
     $ wp cache set my_key my_value my_group 300
     Success: Set object 'my_key' in group 'my_group'.
 
     # Get cache.
-    $ wp cache get my_key my_group
-    my_value
-`
-
-### Examples
-
-    \# Set cache.
-    $ wp cache set my_key my_value my_group 300
-    Success: Set object 'my_key' in group 'my_group'.
-
-    \# Get cache.
     $ wp cache get my_key my_group
     my_value
 

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -2,7 +2,7 @@
 
 Manipulates the WP Object Cache.
 
-Use a persistent ([object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache)) drop-in to persist cache values between requests.
+Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache) drop-in to persist cache values between requests.
 
 ### Examples
 

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -6,6 +6,18 @@ Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_O
 
 ### Examples
 
+`
+    # Set cache.
+    $ wp cache set my_key my_value my_group 300
+    Success: Set object 'my_key' in group 'my_group'.
+
+    # Get cache.
+    $ wp cache get my_key my_group
+    my_value
+`
+
+### Examples
+
     \# Set cache.
     $ wp cache set my_key my_value my_group 300
     Success: Set object 'my_key' in group 'my_group'.

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -5,24 +5,15 @@ Manipulates the WP Object Cache.
 Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache) drop-in to persist cache values between requests.
 
 ### Examples
+```
+# Set cache.
+$ wp cache set my_key my_value my_group 300
+Success: Set object 'my_key' in group 'my_group'.
 
-    # Set cache.
-    $ wp cache set my_key my_value my_group 300
-    Success: Set object 'my_key' in group 'my_group'.
-   
-    # Get cache.
-    $ wp cache get my_key my_group
-    my_value
+# Get cache.
+$ wp cache get my_key my_group
+my_value
+```
 
-
-### Examples
-
-    # Set cache.
-    $ wp cache set my_key my_value my_group 300
-    Success: Set object 'my_key' in group 'my_group'.
-
-    # Get cache.
-    $ wp cache get my_key my_group
-    my_value
 
 

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -4,7 +4,7 @@ Manipulates the WP Object Cache.
 
 Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache) drop-in to persist cache values between requests.
 
-### Examples
+### EXAMPLES
 
     # Set cache.
     $ wp cache set my_key my_value my_group 300

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -6,11 +6,11 @@ Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_O
 
 ### Examples
 
-    # Set cache.
+    \# Set cache.
     $ wp cache set my_key my_value my_group 300
     Success: Set object 'my_key' in group 'my_group'.
 
-    # Get cache.
+    \# Get cache.
     $ wp cache get my_key my_group
     my_value
 

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -1,10 +1,10 @@
 # wp cache
 
-Manage the object cache.
+Manipulates the WP Object Cache.
 
-Use a persistent object cache drop-in to persist cache values between requests.
+Use a persistent ([object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache)) drop-in to persist cache values between requests.
 
-### EXAMPLES
+### Examples
 
     # Set cache.
     $ wp cache set my_key my_value my_group 300

--- a/commands/cache.md
+++ b/commands/cache.md
@@ -5,15 +5,11 @@ Manipulates the WP Object Cache.
 Use a persistent [object cache](https://codex.wordpress.org/Class_Reference/WP_Object_Cache) drop-in to persist cache values between requests.
 
 ### Examples
-```
-# Set cache.
-$ wp cache set my_key my_value my_group 300
-Success: Set object 'my_key' in group 'my_group'.
 
-# Get cache.
-$ wp cache get my_key my_group
-my_value
-```
+    # Set cache.
+    $ wp cache set my_key my_value my_group 300
+    Success: Set object 'my_key' in group 'my_group'.
 
-
-
+    # Get cache.
+    $ wp cache get my_key my_group
+    my_value

--- a/commands/cap.md
+++ b/commands/cap.md
@@ -1,6 +1,6 @@
 # wp cap
 
-Manage user capabilities.
+Adds to, removes from, and lists capabilities of a user role.
 
 ### EXAMPLES
 

--- a/commands/cap.md
+++ b/commands/cap.md
@@ -2,7 +2,7 @@
 
 Adds to, removes from, and lists capabilities of a user role.
 
-### EXAMPLES
+### Examples
 
     # Add 'spectate' capability to 'author' role.
     $ wp cap add 'author' 'spectate'

--- a/commands/cap.md
+++ b/commands/cap.md
@@ -1,6 +1,6 @@
 # wp cap
 
-Adds to, removes from, and lists capabilities of a user role.
+Adds, removes, and lists capabilities of a user role.
 
 ### Examples
 

--- a/commands/checksum.md
+++ b/commands/checksum.md
@@ -1,6 +1,6 @@
 # wp checksum
 
-Verify WordPress core checksums.
+Compares the site's core files with core at WordPress.org (via checksums).
 
 
 

--- a/commands/cli.md
+++ b/commands/cli.md
@@ -1,8 +1,8 @@
 # wp cli
 
-Review current WP-CLI info, check for updates, or see defined aliases.
+Updates WP-CLI and displays its parameters, aliases, and environmental details.
 
-### EXAMPLES
+### Examples
 
     # Display the version currently installed.
     $ wp cli version

--- a/commands/cli.md
+++ b/commands/cli.md
@@ -1,6 +1,6 @@
 # wp cli
 
-Updates WP-CLI and displays its parameters, aliases, and environmental details.
+Updates WP-CLI, displays its parameters, aliases, and environmental details.
 
 ### Examples
 

--- a/commands/comment.md
+++ b/commands/comment.md
@@ -1,8 +1,8 @@
 # wp comment
 
-Manage comments.
+Creates, updates, deletes, and moderates comments.
 
-### EXAMPLES
+### Examples
 
     # Create a new comment.
     $ wp comment create --comment_post_ID=15 --comment_content="hello blog" --comment_author="wp-cli"

--- a/commands/config.md
+++ b/commands/config.md
@@ -1,6 +1,8 @@
 # wp config
 
-Manage the wp-config.php file
+Generates and displays information about the site's wp-config.php file.
+
+The [wp-config file](https://codex.wordpress.org/Editing_wp-config.php) contains the site's base configuration details, such as database connection information.
 
 
 

--- a/commands/core.md
+++ b/commands/core.md
@@ -1,8 +1,8 @@
 # wp core
 
-Download, install, update and manage a WordPress install.
+Downloads, installs, updates, and manages a WordPress installation.
 
-### EXAMPLES
+### Examples
 
     # Download WordPress core
     $ wp core download --locale=nl_NL

--- a/commands/cron.md
+++ b/commands/cron.md
@@ -1,8 +1,10 @@
 # wp cron
 
-Manage WP-Cron events and schedules.
+Manages WP-Cron automation events and schedule.
 
-### EXAMPLES
+[WP-Cron](https://developer.wordpress.org/plugins/cron/) is how WordPress handles scheduling time-based tasks in WordPress on UNIX systems.
+
+### Examples
 
     # Test WP Cron spawning system
     $ wp cron test

--- a/commands/db.md
+++ b/commands/db.md
@@ -1,8 +1,10 @@
 # wp db
 
-Perform basic database operations using credentials stored in wp-config.php
+Performs basic database operations using the wp-config credentials.
 
-### EXAMPLES
+Retrieve info on and run SQL commands in the [WordPress database](https://codex.wordpress.org/Database_Description).
+
+### Examples
 
     # Create a new database.
     $ wp db create

--- a/commands/eval-file.md
+++ b/commands/eval-file.md
@@ -2,7 +2,7 @@
 
 Load and execute a PHP file.
 
-### OPTIONS
+### Options
 
 &lt;file&gt;
 : The path to the PHP file to execute.
@@ -13,7 +13,7 @@ Load and execute a PHP file.
 [\--skip-wordpress]
 : Load and execute file without loading WordPress.
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/eval-file.md
+++ b/commands/eval-file.md
@@ -1,6 +1,6 @@
 # wp eval-file
 
-Load and execute a PHP file.
+Loads and executes a PHP file.
 
 ### Options
 

--- a/commands/eval.md
+++ b/commands/eval.md
@@ -1,8 +1,8 @@
 # wp eval
 
-Execute arbitrary PHP code.
+Executes and tests PHP commands passed as parameters.
 
-### OPTIONS
+### Options
 
 &lt;php-code&gt;
 : The code to execute, as a string.
@@ -10,7 +10,7 @@ Execute arbitrary PHP code.
 [\--skip-wordpress]
 : Execute code without loading WordPress.
 
-### EXAMPLES
+### Examples
 
     # Display WordPress content directory.
     $ wp eval 'echo WP_CONTENT_DIR;'
@@ -20,7 +20,7 @@ Execute arbitrary PHP code.
     $ wp eval 'echo rand();' --skip-wordpress
     479620423
 
-### GLOBAL PARAMETERS
+### Global Parmaeters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/export.md
+++ b/commands/export.md
@@ -1,12 +1,12 @@
 # wp export
 
-Export WordPress content to a WXR file.
+Exports selected database content into a WordPress eXtended RSS (WXR) file.
 
 Generates one or more WXR files containing authors, terms, posts,
 comments, and attachments. WXR files do not include site configuration
 (options) or the attachment files themselves.
 
-### OPTIONS
+### Options
 
 [\--dir=&lt;dirname&gt;]
 : Full path to directory where WXR export files should be stored. Defaults
@@ -21,7 +21,7 @@ to current working directory.
 default: 15
 \---
 
-### FILTERS
+### Filters
 
 [\--start_date=&lt;date&gt;]
 : Export only posts published after this date, in format YYYY-MM-DD.
@@ -58,7 +58,7 @@ with a comma. Defaults to none.
 [\--filename_format=&lt;format&gt;]
 : Use a custom format for export filenames. Defaults to '{site}.wordpress.{date}.{n}.xml'.
 
-### EXAMPLES
+### Examples
 
     # Export posts published by the user between given start and end date
     $ wp export --dir=/tmp/ --user=admin --post_type=post --start_date=2011-01-01 --end_date=2011-12-31
@@ -78,7 +78,7 @@ with a comma. Defaults to none.
     Writing to file /var/www/example.com/public_html/staging.wordpress.2016-05-24.000.xml
     Success: All done with export.
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/help.md
+++ b/commands/help.md
@@ -1,13 +1,13 @@
 # wp help
 
-Get help on WP-CLI, or on a specific command.
+Accesses the manual for WP-CLI and its commands.
 
-### OPTIONS
+### Options
 
 [&lt;command&gt;...]
 : Get help on a specific command.
 
-### EXAMPLES
+### Examples
 
     # get help for `core` command
     wp help core
@@ -15,7 +15,7 @@ Get help on WP-CLI, or on a specific command.
     # get help for `core download` subcommand
     wp help core download
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/import.md
+++ b/commands/import.md
@@ -1,11 +1,10 @@
 # wp import
 
-Import content from a WXR file.
+Imports content from a WordPress eXtended RSS (WXR) file into the database.
 
-Provides a command line interface to the WordPress Importer plugin, for
-performing data migrations.
+Provides a command line interface to the WordPress Importer plugin, for performing data migrations.
 
-### OPTIONS
+### Options
 
 &lt;file&gt;...
 : Path to one or more valid WXR files for importing. Directories are also accepted.
@@ -16,7 +15,7 @@ performing data migrations.
 [\--skip=&lt;data-type&gt;]
 : Skip importing specific data. Supported options are: 'attachment' and 'image_resize' (skip time-consuming thumbnail generation).
 
-### EXAMPLES
+### Examples
 
     # Import content from a WXR file
     $ wp import example.wordpress.2016-06-21.xml --authors=create
@@ -27,7 +26,7 @@ performing data migrations.
     -- Imported post as post_id #1
     Success: Finished importing from 'example.wordpress.2016-06-21.xml' file.
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/language.md
+++ b/commands/language.md
@@ -1,6 +1,6 @@
 # wp language
 
-
+Manages the language setting for the WordPress site.
 
 
 

--- a/commands/language.md
+++ b/commands/language.md
@@ -2,6 +2,6 @@
 
 Manages the language setting for the WordPress site.
 
-
+WordPress displays in U.S. English by default but can be use many other [language translations](https://codex.wordpress.org/Installing_WordPress_in_Your_Language).
 
 

--- a/commands/media.md
+++ b/commands/media.md
@@ -1,8 +1,8 @@
 # wp media
 
-Import new attachments or regenerate existing ones.
+Imports files as attachments and regenerates thumbnails.
 
-### EXAMPLES
+### Examples
 
     # Re-generate all thumbnails, without confirmation.
     $ wp media regenerate --yes

--- a/commands/menu.md
+++ b/commands/menu.md
@@ -1,8 +1,10 @@
 # wp menu
 
-List, create, assign, and delete menus.
+Manages menus for the WordPress site.
 
-### EXAMPLES
+Lists, creates, assigns, and deletes the active theme's [navigation menus](https://developer.wordpress.org/themes/functionality/navigation-menus/).
+
+### Examples
 
     # Create a new menu
     $ wp menu create "My Menu"

--- a/commands/network.md
+++ b/commands/network.md
@@ -1,6 +1,6 @@
 # wp network
 
-
+Manages meta fields for multisite networks.
 
 
 

--- a/commands/option.md
+++ b/commands/option.md
@@ -1,8 +1,11 @@
 # wp option
 
-Manage options.
+Retrieves and sets site options, including plugin and WordPress settings.
 
-### EXAMPLES
+See the [Plugin Settings API](https://developer.wordpress.org/plugins/settings/settings-api/) and the 
+[Theme Options](https://developer.wordpress.org/themes/customize-api/) for more information on adding customized options.
+
+### Examples
 
     # Get site URL.
     $ wp option get siteurl

--- a/commands/package.md
+++ b/commands/package.md
@@ -1,6 +1,6 @@
 # wp package
 
-Manage WP-CLI packages.
+Runs WP-CLI package manager commands.
 
 WP-CLI packages are community-maintained projects built on WP-CLI. They can
 contain WP-CLI commands, but they can also just extend WP-CLI in some way.
@@ -11,7 +11,7 @@ Installable packages are listed in the
 Learn how to create your own command from the
 [Commands Cookbook](http://wp-cli.org/docs/commands-cookbook/)
 
-### EXAMPLES
+### Examples
 
     # List installed packages
     $ wp package list

--- a/commands/plugin.md
+++ b/commands/plugin.md
@@ -1,8 +1,8 @@
 # wp plugin
 
-Manage plugins.
+Manages site plugins, including installs, activations, and updates.
 
-### EXAMPLES
+### Examples
 
     # Activate plugin
     $ wp plugin activate hello

--- a/commands/post-type.md
+++ b/commands/post-type.md
@@ -2,7 +2,7 @@
 
 Retrieves information on the site's registered post-types.
 
-Get details on built-in and [custom post types](https://developer.wordpress.org/plugins/post-types/).
+Get details on WordPress built-in and [custom post types](https://developer.wordpress.org/plugins/post-types/).
 
 ### Examples
 

--- a/commands/post-type.md
+++ b/commands/post-type.md
@@ -1,8 +1,10 @@
 # wp post-type
 
-Manage post types.
+Retrieves information on the site's registered post-types.
 
-### EXAMPLES
+Get details on built-in and [custom post types](https://developer.wordpress.org/plugins/post-types/).
+
+### Examples
 
     # Get details about a post type
     $ wp post-type get page --fields=name,label,hierarchical --format=json

--- a/commands/post.md
+++ b/commands/post.md
@@ -1,8 +1,8 @@
 # wp post
 
-Manage posts.
+Manages posts, content, and meta.
 
-### EXAMPLES
+### Examples
 
     # Create a new post.
     $ wp post create --post_type=post --post_title='A sample post'

--- a/commands/rewrite.md
+++ b/commands/rewrite.md
@@ -1,8 +1,10 @@
 # wp rewrite
 
-Manage rewrite rules.
+Lists or flushes the site's rewrite rules, updates the permalink structure.
 
-### EXAMPLES
+See the WordPress [Rewrite API](https://codex.wordpress.org/Rewrite_API) and [WP Rewrite](https://codex.wordpress.org/Class_Reference/WP_Rewrite) class reference.
+
+### Examples
 
     # Flush rewrite rules
     $ wp rewrite flush

--- a/commands/role.md
+++ b/commands/role.md
@@ -1,8 +1,8 @@
 # wp role
 
-Manage user roles.
+Manages user roles, including creating new roles and resetting to defaults.
 
-### EXAMPLES
+### Examples
 
     # List roles.
     $ wp role list --fields=role --format=csv

--- a/commands/scaffold.md
+++ b/commands/scaffold.md
@@ -1,8 +1,10 @@
 # wp scaffold
 
-Generate code for post types, taxonomies, plugins, child themes, etc.
+Generates unit tests, child and \_s themes, registers CPTs and taxonomies.
 
-### EXAMPLES
+See references for [Automated Testing](https://make.wordpress.org/core/handbook/testing/automated-testing/), [Theme Unit Test](https://codex.wordpress.org/Theme_Unit_Test), [Plugin Unit Tests](https://make.wordpress.org/cli/handbook/plugin-unit-tests/), [child themes](https://codex.wordpress.org/Child_Themes), the [Underscores starter theme](https://underscores.me/), [custom post types](https://developer.wordpress.org/plugins/post-types/), and [custom taxonomies](https://developer.wordpress.org/plugins/taxonomies/working-with-custom-taxonomies/).
+
+### Examples
 
     # Generate a new plugin with unit tests
     $ wp scaffold plugin sample-plugin
@@ -16,5 +18,3 @@ Generate code for post types, taxonomies, plugins, child themes, etc.
     # Generate code for post type registration in given theme
     $ wp scaffold post-type movie --label=Movie --theme=simple-life
     Success: Created /var/www/example.com/public_html/wp-content/themes/simple-life/post-types/movie.php
-
-

--- a/commands/search-replace.md
+++ b/commands/search-replace.md
@@ -1,18 +1,14 @@
 # wp search-replace
 
-Search/replace strings in the database.
+Searches and replaces strings in the database (regex permitted).
 
-Searches through all rows in a selection of tables and replaces
-appearances of the first string with the second string.
+Searches through all rows in a selection of tables and replaces appearances of the first string with the second string.
 
-By default, the command uses tables registered to the `$wpdb` object. On
-multisite, this will just be the tables for the current site unless
-`--network` is specified.
+By default, the command uses tables registered to the `$wpdb` object. On multisite, this will just be the tables for the current site unless `--network` is specified.
 
-Search/replace intelligently handles PHP serialized data, and does not
-change primary key values.
+Search/replace intelligently handles PHP serialized data, and does not change primary key values.
 
-### OPTIONS
+### Options
 
 &lt;old&gt;
 : A string to search for within the database.
@@ -85,7 +81,7 @@ options:
   - count
 \---
 
-### EXAMPLES
+### Examples
 
     # Search and replace but skip one column
     $ wp search-replace 'http://example.dev' 'http://example.com' --skip-columns=guid
@@ -110,7 +106,7 @@ options:
         wp search-replace 'http://example.com' 'http://example.dev' --recurse-objects --skip-columns=guid
     fi
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/server.md
+++ b/commands/server.md
@@ -1,11 +1,11 @@
 # wp server
 
-Launch PHP's built-in web server for this specific WordPress installation.
+Launches PHP's built-in web server for this specific WordPress installation.
 
 Uses `php -S` to launch a web server serving the WordPress webroot.
 &lt;http://php.net/manual/en/features.commandline.webserver.php&gt;
 
-### OPTIONS
+### Options
 
 [\--host=&lt;host&gt;]
 : The hostname to bind the server to.
@@ -26,7 +26,7 @@ set, the default value is it.
 [\--config=&lt;file&gt;]
 : Configure the server with a specific .ini file.
 
-### EXAMPLES
+### Examples
 
     # Make the instance available on any address (with port 8080)
     $ wp server --host=0.0.0.0
@@ -49,7 +49,7 @@ set, the default value is it.
     Document root is /
     Press Ctrl-C to quit.
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/shell.md
+++ b/commands/shell.md
@@ -1,26 +1,22 @@
 # wp shell
 
-Interactive PHP console.
+Opens an interactive PHP console for running and testing PHP code. 
 
-`wp shell` allows you to evaluate PHP statements and expressions
-interactively, from within a WordPress environment. Type a bit of code,
-hit enter, and see the code execute right before you. Because WordPress
-is loaded, you have access to all the functions, classes and globals
-that you can use within a WordPress plugin, for example.
+`wp shell` allows you to evaluate PHP statements and expressions interactively, from within a WordPress environment. Type a bit of code, hit enter, and see the code execute right before you. Because WordPress is loaded, you have access to all the functions, classes and globals that you can use within a WordPress plugin, for example.
 
-### OPTIONS
+### Options
 
 [\--basic]
 : Start in fail-safe mode, even if Boris is available.
 
-### EXAMPLES
+### Examples
 
     # Call get_bloginfo() to get the name of the site.
     $ wp shell
     wp> get_bloginfo( 'name' );
     => string(6) "WP-CLI"
 
-### GLOBAL PARAMETERS
+### Global Parameters
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
 

--- a/commands/sidebar.md
+++ b/commands/sidebar.md
@@ -1,13 +1,13 @@
 # wp sidebar
 
-Manage sidebars.
+Lists registered sidebars.
 
-### EXAMPLES
+A [sidebar](https://developer.wordpress.org/themes/functionality/sidebars/) is any widgetized area of your theme.
+
+### Examples
 
     # List sidebars
     $ wp sidebar list --fields=name,id --format=csv
     name,id
     "Widget Area",sidebar-1
     "Inactive Widgets",wp_inactive_widgets
-
-

--- a/commands/site.md
+++ b/commands/site.md
@@ -1,8 +1,8 @@
 # wp site
 
-Perform site-wide operations.
+Performs site-wide operations on a multisite install.
 
-### EXAMPLES
+### Examples
 
     # Create site
     $ wp site create --slug=example
@@ -17,5 +17,3 @@ Perform site-wide operations.
     $ wp site delete 123
     Are you sure you want to delete the 'http://www.example.com/example' site? [y/n] y
     Success: The site at 'http://www.example.com/example' was deleted.
-
-

--- a/commands/super-admin.md
+++ b/commands/super-admin.md
@@ -1,8 +1,8 @@
 # wp super-admin
 
-Manage super admins on WordPress multisite.
+Lists, adds, or removes super admin users on a multisite install.
 
-### EXAMPLES
+### Examples
 
     # List user with super-admin capabilities
     $ wp super-admin list
@@ -16,5 +16,4 @@ Manage super admins on WordPress multisite.
     # Revoke super-admin privileges to the user.
     $ wp super-admin remove superadmin2
     Success: Revoked super-admin capabilities.
-
-
+ 

--- a/commands/taxonomy.md
+++ b/commands/taxonomy.md
@@ -1,8 +1,10 @@
 # wp taxonomy
 
-Manage taxonomies.
+Retrieves information about registered taxonomies.
 
-### EXAMPLES
+See references for [built-in taxonomies](https://developer.wordpress.org/themes/basics/categories-tags-custom-taxonomies/) and [custom taxonomies](https://developer.wordpress.org/plugins/taxonomies/working-with-custom-taxonomies/).
+
+### Examples
 
     # List all taxonomies with 'post' object type.
     $ wp taxonomy list --object_type=post --fields=name,public
@@ -17,5 +19,3 @@ Manage taxonomies.
     # Get capabilities of 'post_tag' taxonomy.
     $ wp taxonomy get post_tag --field=cap
     {"manage_terms":"manage_categories","edit_terms":"manage_categories","delete_terms":"manage_categories","assign_terms":"edit_posts"}
-
-

--- a/commands/term.md
+++ b/commands/term.md
@@ -1,8 +1,10 @@
 # wp term
 
-Manage terms.
+Manages taxonomy terms and term meta, including create, delete, and list.
 
-### EXAMPLES
+See reference for [taxonomies and their terms](https://codex.wordpress.org/Taxonomies).
+
+### Examples
 
     # Create a new term.
     $ wp term create category Apple --description="A type of fruit"
@@ -28,5 +30,3 @@ Manage terms.
     $ wp term recount category post_tag
     Success: Updated category term count
     Success: Updated post_tag term count
-
-

--- a/commands/theme.md
+++ b/commands/theme.md
@@ -1,8 +1,8 @@
 # wp theme
 
-Manage themes.
+Manages site themes, including installs, activations, and updates.
 
-### EXAMPLES
+### Examples
 
     # Install the latest version of a theme from wordpress.org and activate
     $ wp theme install twentysixteen --activate
@@ -31,5 +31,3 @@ Manage themes.
     		Status: Active
     		Version: 1.2
     		Author: the WordPress team
-
-

--- a/commands/transient.md
+++ b/commands/transient.md
@@ -1,8 +1,11 @@
 # wp transient
 
-Manage transients.
+Retrieves and sets data stored as WordPress transients.
 
-### EXAMPLES
+See reference for the [Transients API](https://codex.wordpress.org/Transients_API).
+
+
+### Examples
 
     # Set transient.
     $ wp transient set sample_key "test data" 3600
@@ -23,5 +26,3 @@ Manage transients.
     # Delete all transients.
     $ wp transient delete --all
     Success: 14 transients deleted from the database.
-
-

--- a/commands/transient.md
+++ b/commands/transient.md
@@ -5,7 +5,7 @@ Retrieves and sets data stored as WordPress transients.
 See reference for the [Transients API](https://codex.wordpress.org/Transients_API).
 
 
-## Examples
+### Examples
 
     # Set transient.
     $ wp transient set sample_key "test data" 3600

--- a/commands/transient.md
+++ b/commands/transient.md
@@ -5,7 +5,7 @@ Retrieves and sets data stored as WordPress transients.
 See reference for the [Transients API](https://codex.wordpress.org/Transients_API).
 
 
-### Examples
+## Examples
 
     # Set transient.
     $ wp transient set sample_key "test data" 3600

--- a/commands/user.md
+++ b/commands/user.md
@@ -1,8 +1,10 @@
 # wp user
 
-Manage users.
+Manages users, along with their roles, capabilities, and meta.
 
-### EXAMPLES
+See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
+
+### Examples
 
     # List user IDs
     $ wp user list --field=ID
@@ -20,5 +22,3 @@ Manage users.
     # Delete user 123 and reassign posts to user 567
     $ wp user delete 123 --reassign=567
     Success: Removed user 123 from http://example.com
-
-

--- a/commands/widget.md
+++ b/commands/widget.md
@@ -1,8 +1,10 @@
 # wp widget
 
-Manage sidebar widgets.
+Manages widgets, including adding and moving them within sidebars.
 
-### EXAMPLES
+A [widget](https://developer.wordpress.org/themes/functionality/widgets/) adds content and features to a widget area (also called a [sidebar](https://developer.wordpress.org/themes/functionality/sidebars/)).
+
+### Examples
 
     # List widgets on a given sidebar
     $ wp widget list sidebar-1
@@ -24,5 +26,3 @@ Manage sidebar widgets.
     # Delete one or more widgets entirely
     $ wp widget delete calendar-2 archive-1
     Success: 2 widgets removed from sidebar.
-
-


### PR DESCRIPTION
Also: 
* Match WP Code Ref grammar for headings: Cap-word (instead of CAP).
* Add Codex or Handbook links to some commands.
Done for WordCamp for Publishers: Contributor Day 2017.

Note: Something in the CLI Handbook's existing Examples syntax is causing page displays to break -- sometimes. Will do some testing.