### PR TITLE
Removing a redundant word "possible" on a sentence

### DIFF
--- a/code-review.md
+++ b/code-review.md
@@ -48,7 +48,7 @@ Finally, check for elegance and overall quality. Code should follow existing and
 
 *As the person receiving the code review*, your job is to learn from suggestions. Defensiveness, stubbornness, or impatience can prevent you from getting the most out of suggestions. It's OK to explain yourself if you feel the reviewer seemed to misunderstand your intent. Arguing semantics or insisting on the correctness of one approach is almost always a bad habit and distracts from the team process. If something isn't clear to someone familiar with the codebase who's reviewing your work today, it will definitely be unclear to a new developer being on-boarded six months from now.
 
-It's best to respond to the issues addressed by the reviewer as quickly as possible possible. Keep in mind that the review process requires context switching on the part of the reviewer as well as on your part, and the more immediate that process is, the less disruptive that context switch will be.
+It's best to respond to the issues addressed by the reviewer as quickly as possible. Keep in mind that the review process requires context switching on the part of the reviewer as well as on your part, and the more immediate that process is, the less disruptive that context switch will be.
 
 ## Additional readings
 


### PR DESCRIPTION
I believe it's just a typo.