### PR TITLE
Update release steps for patch releases

### DIFF
--- a/release-checklist.md
+++ b/release-checklist.md
@@ -143,28 +143,26 @@ For instance, if the release version was `0.24.0`, the version should be bumped 
 
 ## Patch releases
 
-Creating a patch release (e.g. 0.23.x) is bit different of a process than creating a major or minor release. At a high-level, here are the steps involved:
+Creating a patch release (e.g. 1.4.x) is bit different of a process than creating a major or minor release. At a high-level, here are the steps involved:
 
 1) Create a new release branch from the last tagged patch release:
 
-    $ git checkout v0.23.0
-    Note: checking out 'v0.23.0'
+    $ git checkout v1.4.0
+    Note: checking out 'v1.4.0'
     You are in 'detached HEAD' state. You can look around, make experimental
     changes and commit them, and you can discard any commits you make in this
     state without impacting any branches by performing another checkout.
-    $ git checkout -b release-0-23-1
-    Switched to a new branch 'release-0-23-1'
+    $ git checkout -b release-1-4-1
+    Switched to a new branch 'release-1-4-1'
 
-2) Cherry-pick existing commits to the new release branch.
+2) Cherry-pick existing commits and package versions to the new release branch.
 
 Because patch releases should just be used for bug fixes, you should first fix the bug on master, and then cherry-pick the fix to the release branch. It's up to your discretion as to whether you cherry-pick the commits directly to the release branch *or* create a feature branch and pull request against the release branch.
 
+If the bug existed in a package, you'll need to create a point release above the last bundled version for the package and update `composer.lock` to load that point release.
+
 3) Update `VERSION` on the release branch to the new release version.
 
-4) **PROCEED WITH EXTREME CAUTION**. While the normal release process yields a built, fully-tested Phar file, the patch release process does not because the build system only pushes the Phar file on the master branch. As such, you need to manually build the Phar file for distribution.
+4) Travis deploys `release-*` branches to the wp-cli/builds repo. Move the generated `wp-cli-release.phar*` files (Phar plus hashes) to `wp-cli.phar*`.
 
-    php -dphar.readonly=0 utils/make-phar.php wp-cli.phar --quiet
-
-When you do so, run `composer install` to make sure you're using the appropriate Composer dependency versions for the release, not the master branch you normally work from. Once you've verified the built Phar, you'll need to copy it over to the builds repo.
-
-5) Follow all of the other relevant release steps.
+5) Follow all of the other relevant major/minor release steps.


### PR DESCRIPTION
1. Phar builds are now automatically created for release branches.
2. Include details on how to incorporate bug fixes to packages.

See https://github.com/wp-cli/wp-cli/issues/4496