### PR TITLE
Fix package-index link.

### DIFF
--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -24,7 +24,7 @@ Third-party commands:
 
 * Can be defined in plugins or themes.
 * Can be easily scaffolded as standalone projects with `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)).
-* Can be distributed independent of a plugin or theme in the [Package Index](http://wp-cli.org/package-index/).
+* Can be distributed independent of a plugin or theme in the [Package Index](https://wp-cli.org/package-index/).
 
 All commands:
 

--- a/commands/package/browse.md
+++ b/commands/package/browse.md
@@ -2,7 +2,7 @@
 
 Browse WP-CLI packages available for installation.
 
-Lists packages available for installation from the [Package Index](http://wp-cli.org/package-index/). Although the package index will remain in place for backward compatibility reasons, it has been deprecated and will not be updated further. Please refer to https://github.com/wp-cli/ideas/issues/51 to read about its potential replacement.
+Lists packages available for installation from the [Package Index](https://wp-cli.org/package-index/). Although the package index will remain in place for backward compatibility reasons, it has been deprecated and will not be updated further. Please refer to https://github.com/wp-cli/ideas/issues/51 to read about its potential replacement.
 
 ### OPTIONS
 

--- a/tools.md
+++ b/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-The following is a list of projects that integrate with WP-CLI in some form. For installable WP-CLI packages, please see the [package index](/package-index/).
+The following is a list of projects that integrate with WP-CLI in some form. For installable WP-CLI packages, please see the [package index](https://wp-cli.org/package-index/).
 
 ## Plugins
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/4532

Fixes package-index link on `tools.md` and http -> https on two others.