### PR TITLE
Fix command summary formatting error.

### DIFF
--- a/internal-api/wp-cli-run-command.md
+++ b/internal-api/wp-cli-run-command.md
@@ -1,6 +1,7 @@
 # WP_CLI::run_command()
 
-Run a given command within the current process using the same global
+Run a given command within the current process using the same global 
+parameters.
 
 ***
 
@@ -17,8 +18,6 @@ Run a given command within the current process using the same global
 ***
 
 ## Notes
-
-parameters.
 
 Use `WP_CLI::runcommand()` instead, which is easier to use and works better.
 


### PR DESCRIPTION
Fix formatting error on WP_CLI::run_command() handbook page.

Resolves #185