### PR TITLE
Update docblock parser to allow for multiple line short descriptions

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -565,7 +565,7 @@ EOT;
 		$ret['description'] = str_replace( '\/', '/', trim( $ret['description'], PHP_EOL ) );
 		$bits = explode( PHP_EOL, $ret['description'] );
 		$short_desc = array( array_shift( $bits ) );
-		if ( !empty( $bits[0] ) ) {
+		while ( isset( $bits[0] ) && ! empty( $bits[0] ) ) {
 			$short_desc[] = array_shift( $bits );
 		}
 		$ret['short_description'] = trim( implode( PHP_EOL, $short_desc ), PHP_EOL );

--- a/bin/command.php
+++ b/bin/command.php
@@ -517,7 +517,10 @@ EOT;
 	}
 
 	/**
-	 * Parse PHPDoc into a structured representation
+	 * Parse PHPDoc into a structured representation.
+	 * 
+	 * @param string $docblock
+	 * @return array
 	 */
 	private static function parse_docblock( $docblock ) {
 		$ret = array(
@@ -561,7 +564,11 @@ EOT;
 		}
 		$ret['description'] = str_replace( '\/', '/', trim( $ret['description'], PHP_EOL ) );
 		$bits = explode( PHP_EOL, $ret['description'] );
-		$ret['short_description'] = array_shift( $bits );
+		$short_desc = array( array_shift( $bits ) );
+		if ( !empty( $bits[0] ) ) {
+			$short_desc[] = array_shift( $bits );
+		}
+		$ret['short_description'] = trim( implode( PHP_EOL, $short_desc ), PHP_EOL );
 		$long_description = trim( implode( PHP_EOL, $bits ), PHP_EOL );
 		$ret['long_description'] = $long_description;
 		return $ret;

--- a/bin/command.php
+++ b/bin/command.php
@@ -568,7 +568,7 @@ EOT;
 		while ( isset( $bits[0] ) && ! empty( $bits[0] ) ) {
 			$short_desc[] = array_shift( $bits );
 		}
-		$ret['short_description'] = trim( implode( PHP_EOL, $short_desc ), PHP_EOL );
+		$ret['short_description'] = trim( implode( ' ', $short_desc ) );
 		$long_description = trim( implode( PHP_EOL, $bits ), PHP_EOL );
 		$ret['long_description'] = $long_description;
 		return $ret;


### PR DESCRIPTION
Fixes error observed when the parsing of `WP_CLI::run_command()` docblock that resulted in a malformed handbook page.

Allows multiple line short descriptions while requiring a blank line after the short description to delineate the remaining inline documentation.

Resolves #185