### PR TITLE
Pass full path to `wp` when raising memory limit

### DIFF
--- a/common-issues.md
+++ b/common-issues.md
@@ -87,7 +87,7 @@ memory_limit = 512M
 Set `memory_limit` on the fly as a temporary fix:
 
 ```bash
-$ php -d memory_limit=512M wp package install <package-name>
+$ php -d memory_limit=512M $(which wp) package install <package-name>
 ```
 
 ### Error: YIKES! It looks like you're running this as root.

--- a/common-issues.md
+++ b/common-issues.md
@@ -87,7 +87,7 @@ memory_limit = 512M
 Set `memory_limit` on the fly as a temporary fix:
 
 ```bash
-$ php -d memory_limit=512M $(which wp) package install <package-name>
+$ php -d memory_limit=512M "$(which wp)" package install <package-name>
 ```
 
 ### Error: YIKES! It looks like you're running this as root.


### PR DESCRIPTION
This command will fail without the full path to `wp` because it is being passed as a parameter rather than being run as an executable which would normally be resolved from the user's `$PATH`.