### PR TITLE
added Pressidium in hosting-companies.md

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -38,4 +38,5 @@ In alphabetical order:
 
 The following is a list of hosting companies that use WP-CLI, whereby their customers can write and request the running of standard and custom WP-CLI commands:
 
+* [Pressidium](https://pressidium.com)
 * [WordPress.com VIP](http://vip.wordpress.com/)


### PR DESCRIPTION
Added [Pressidium](https://pressidium.com) into the list of WordPress hosting companies that allow their customers to request the running of WP-CLI commands.
