### PR TITLE
Added an updraftplus WP CLI command

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -61,6 +61,7 @@ The following table is an alphabetical list of known commands defined in WordPre
 | themecheck            | [wp-cli-themecheck](https://github.com/anhskohbo/wp-cli-themecheck)
 | thinkup               | [Thinkup Import WP CLI Commands](https://github.com/taras/wp-cli-thinkup-import)
 | total-cache           | [W3 Total Cache](http://wordpress.org/extend/plugins/w3-total-cache/)
+| updraftplus           | [UpdraftPlus](https://updraftplus.com/)
 | usergen               | [Generate random users](https://github.com/alessandrotesoro/wp-usergen-cli)
 | Unsplash              | [Import images from Unsplash into your Media Library](https://github.com/A5hleyRich/wp-cli-unsplash-command)
 


### PR DESCRIPTION
The UpdraftPlus Plugin have 1+ million active installs. The UpdraftPlus  plugin gives updraftplus WP CLI command as indicated on the https://updraftplus.com/wp-cli-updraftplus-documentation/.