### PR TITLE
Update hosting-companies.md

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -25,6 +25,7 @@ In alphabetical order:
 * [Monarobase](https://monarobase.net/wordpress)
 * [NameHero](https://www.namehero.com)
 * [NearlyFreeSpeech.NET](https://www.nearlyfreespeech.net/)
+* [Nexcess.Net](https://www.nexcess.net/)
 * [Pagely](https://pagely.com/)
 * [Pantheon](https://pantheon.io)
 * [Pressjitsu](https://pressjitsu.com)


### PR DESCRIPTION
Nexcess.Net offers Wordpress hosting with SSH access. wp-cli is included by default.