### PR TITLE
Use example.com as placeholder

### DIFF
--- a/common-issues.md
+++ b/common-issues.md
@@ -111,7 +111,7 @@ Before accessing a value on the `$_SERVER` superglobal, you should check if the 
 When using `$_SERVER['HTTP_HOST']` in your `wp-config.php`, you'll need to set a default value in WP-CLI context:
 
     if ( defined( 'WP_CLI' ) && WP_CLI && ! isset( $_SERVER['HTTP_HOST'] ) ) {
-        $_SERVER['HTTP_HOST'] = 'wp-cli.org';
+        $_SERVER['HTTP_HOST'] = 'example.com';
     }
 
 See also: [#730](https://github.com/wp-cli/wp-cli/issues/730)


### PR DESCRIPTION
The URL wp-cli.org as placeholder for the server constant could be mistaken as "a link to the wp-cli project".