### PR TITLE
Added Host4Geeks

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -14,6 +14,7 @@ In alphabetical order:
 * [Dreamhost](http://dreamhost.com)
 * [FatCow](http://www.fatcow.com/wordpress-hosting/)
 * [GoDaddy](https://www.godaddy.com/help/accessing-wp-cli-on-your-managed-wordpress-account-12066)
+* [Host4Geeks](https://host4geeks.com/managed-wordpress-hosting)
 * [HostGalaxy](https://www.hostgalaxy.com)
 * [HostGator](http://www.hostgator.com)
 * [Hostinger](https://www.hostinger.com)


### PR DESCRIPTION
Added Host4Geeks to the list, that offers WP-CLI out of the box with its managed WordPress hosting plans.