### PR TITLE
Added ICDSoft to list

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -18,6 +18,7 @@ In alphabetical order:
 * [HostGalaxy](https://www.hostgalaxy.com)
 * [HostGator](http://www.hostgator.com)
 * [Hostinger](https://www.hostinger.com)
+* [ICDSoft](https:///www.icdsoft.com)
 * [iPage](http://www.ipage.com/ipage/index.html)
 * [JDM.pl](https://jdm.pl)
 * [Kinsta](https://kinsta.com)


### PR DESCRIPTION
Added ICDSoft to list - WP-CLI is provided to all users on all plans, as outlined at https://www.icdsoft.com/en/hosting/wordpress#/sharedplans