### PR TITLE
Update link to command list in Quick Start

### DIFF
--- a/quick-start.md
+++ b/quick-start.md
@@ -124,4 +124,4 @@ Found 1 image to regenerate.
 Success: Finished regenerating the image.
 ```
 
-Wondering what's next? Browse through [all of WP-CLI's commands](https://wp-cli.org/commands/) to explore your new world. Or, catch up with [shell friends](https://make.wordpress.org/cli/handbook/shell-friends/) to learn about helpful command line utilities.
+Wondering what's next? Browse through [all of WP-CLI's commands](https://developer.wordpress.org/cli/commands/) to explore your new world. Or, catch up with [shell friends](https://make.wordpress.org/cli/handbook/shell-friends/) to learn about helpful command line utilities.


### PR DESCRIPTION
At the end of the quick start a reader can click to learn more about the available commands. They are currently met with a 404 page. From what I can tell this is the correct link now. 