### PR TITLE
Add documentation for the `--foo[=<bar>]` to `command-cookbook.md`

### DIFF
--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -207,7 +207,7 @@ Options defined in the longdesc are interpreted as the command's **synopsis**:
 
 * `<name>` is a required positional argument. Changing it to `<name>...` would mean the command could accept one or more positional arguments.
 * `[--type=<type>]` is an optional associative argument which defaults to 'success' and accepts either 'success' or 'error'. Changing it to `[--error]` would change the argument to behave as an optional boolean flag.
-* `[--field[=<value>]]` allows an optional argument to be used with or without a value. This is the case when using a global parameter like `--skip-plugins[=<plugins>]` which can either skip loading all plugins, or skip a comma-separated list of plugins. 
+* `[--field[=<value>]]` allows an optional argument to be used with or without a value. An example of this would be using a global parameter like `--skip-plugins[=<plugins>]` which can either skip loading all plugins, or skip a comma-separated list of plugins. 
 
 *Note*: To accept arbitrary/unlimited number of optional associative arguments you would use the annotation `[--<field>=<value>]`.  So for example:
 

--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -215,7 +215,6 @@ Options defined in the longdesc are interpreted as the command's **synopsis**:
 	 * [--<field>=<value>]
 	 * : Allow unlimited number of associative parameters.
 ```
-
 A command's synopsis is used for validating the arguments, before passing them to the implementation.
 
 The longdesc is also displayed when calling the `help` command, for example, `wp help example hello`. Its syntax is [Markdown Extra](http://michelf.ca/projects/php-markdown/extra/) and here are a few more notes on how it's handled by WP-CLI:

--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -214,6 +214,14 @@ Options defined in the longdesc are interpreted as the command's **synopsis**:
 	 * [--<field>=<value>]
 	 * : Allow unlimited number of associative parameters.
 ```
+
+*Note*: It is also possible for a command to have an arbitrary/unlimited number of arguments which can optionally have a value. For example:
+
+```
+	* [--<field>[=<value>]]
+	* : Allow unlimited number of associative parameters which can optionally take a value. In this case, the parameter does not require a value, but can have one if needed.
+``` 
+
 A command's synopsis is used for validating the arguments, before passing them to the implementation.
 
 The longdesc is also displayed when calling the `help` command, for example, `wp help example hello`. Its syntax is [Markdown Extra](http://michelf.ca/projects/php-markdown/extra/) and here are a few more notes on how it's handled by WP-CLI:

--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -207,6 +207,7 @@ Options defined in the longdesc are interpreted as the command's **synopsis**:
 
 * `<name>` is a required positional argument. Changing it to `<name>...` would mean the command could accept one or more positional arguments.
 * `[--type=<type>]` is an optional associative argument which defaults to 'success' and accepts either 'success' or 'error'. Changing it to `[--error]` would change the argument to behave as an optional boolean flag.
+* `[--field[=<value>]]` allows an optional argument to be used with or without a value. This is the case when using a global parameter like `--skip-plugins[=<plugins>]` which can either skip loading all plugins, or skip a comma-separated list of plugins. 
 
 *Note*: To accept arbitrary/unlimited number of optional associative arguments you would use the annotation `[--<field>=<value>]`.  So for example:
 
@@ -214,13 +215,6 @@ Options defined in the longdesc are interpreted as the command's **synopsis**:
 	 * [--<field>=<value>]
 	 * : Allow unlimited number of associative parameters.
 ```
-
-*Note*: It is also possible for a command to have an arbitrary/unlimited number of arguments which can optionally have a value. For example:
-
-```
-	* [--<field>[=<value>]]
-	* : Allow unlimited number of associative parameters which can optionally take a value. In this case, the parameter does not require a value, but can have one if needed.
-``` 
 
 A command's synopsis is used for validating the arguments, before passing them to the implementation.
 


### PR DESCRIPTION
Added language to show that it is possible to add an optional number of associative parameters that can optionally have a value.

Fixes #227