### PR TITLE
Remove : before argument description

### DIFF
--- a/commands-cookbook.md
+++ b/commands-cookbook.md
@@ -139,7 +139,7 @@ class Example_Command {
 	 * ## OPTIONS
 	 *
 	 * <name>
-	 * : The name of the person to greet.
+	 * The name of the person to greet.
 	 *
 	 * [--type=<type>]
 	 * : Whether or not to greet the person with success or error.


### PR DESCRIPTION
Remove colon (:) before the argument description in the example
documentation because it is causing an problem with parsing the flag
arguments.

See #301