### PR TITLE
Update example of 'wp config create'

### DIFF
--- a/quick-start.md
+++ b/quick-start.md
@@ -57,7 +57,8 @@ Success: WordPress downloaded.
 
 ```
 $ cd wpclidemo.dev
-$ wp config create --dbname=wpclidemo --dbuser=root
+$ wp config create --dbname=wpclidemo --dbuser=root --prompt=dbpass
+1/10 [--dbpass=<dbpass>]:
 Success: Generated 'wp-config.php' file.
 ```
 


### PR DESCRIPTION
In windows, when we use:
`wp config create --dbname=wpclidemo --dbuser=root`

It returns this error:
> ERROR 2003 (HY000): Can't connect to MySQL server on 'localhost' (10061 "Unknown error")

This is due to the absence of a password, if we add `dbpass` to command, the error will be gone, like:

`wp config create --dbname=wpclidemo --dbuser=root --prompt=dbpass`