### PR TITLE
"Install" is not a noun

### DIFF
--- a/code-review.md
+++ b/code-review.md
@@ -52,6 +52,6 @@ It's best to respond to the issues addressed by the reviewer as quickly as possi
 
 ## Additional readings
 
-* [Glen Sanford: On code review](http://glen.nu/ramblings/oncodereview.php) - "Pending code reviews represent blocked threads of execution[, code review should always be your top priority]"
+* [Glen Sanford: On code review](http://glen.nu/ramblings/oncodereview.php) - "Pending code reviews represent blocked threads of execution[ code review should always be your top priority]"
 
 * [The Ten Commandments of Egoless Programming](http://www.techrepublic.com/article/the-ten-commandments-of-egoless-programming/) - "Understand and accept that you will make mistakes. The point is to find them early before they make it into production." 

--- a/code-review.md
+++ b/code-review.md
@@ -52,6 +52,6 @@ It's best to respond to the issues addressed by the reviewer as quickly as possi
 
 ## Additional readings
 
-* [Glen Sanford: On code review](http://glen.nu/ramblings/oncodereview.php) - "Pending code reviews represent blocked threads of execution[ code review should always be your top priority]"
+* [Glen Sanford: On code review](http://glen.nu/ramblings/oncodereview.php) - "Pending code reviews represent blocked threads of execution[ code review should always be your top priority ]"
 
 * [The Ten Commandments of Egoless Programming](http://www.techrepublic.com/article/the-ten-commandments-of-egoless-programming/) - "Understand and accept that you will make mistakes. The point is to find them early before they make it into production." 

--- a/commands/cli/update.md
+++ b/commands/cli/update.md
@@ -4,7 +4,7 @@ Update WP-CLI to the latest release.
 
 Default behavior is to check the releases API for the newest stable version, and prompt if one is available.
 
-Use `--stable` to install or reinstall the latest stable version.
+Use `--stable` to installation or reinstallation the latest stable version.
 
 Use `--nightly` to install the latest built version of the master branch. While not recommended for production, nightly contains the latest and greatest, and should be stable enough for development and staging environments.
 

--- a/committers-credo.md
+++ b/committers-credo.md
@@ -5,7 +5,7 @@ Some people have write access to WP-CLI repositories. These people are identifie
 * [maintainers](https://github.com/orgs/wp-cli/teams/maintainers) - Project leadership
 * [committers](https://github.com/orgs/wp-cli/teams/committers) - Trusted contributors
 
-This “Committers credo” is a living document. It’s meant to establish generally agreed upon standards for committers, and will continue to evolve over time.
+This “Committers credo” is a living document. It’s meant to establish generally agreed upon standards for committers and will continue to evolve over time.
 
 ## Product quality
 
@@ -15,12 +15,12 @@ Practically-speaking:
 
 * Given a choice between Good, Fast, and Cheap, we pick Good and Slow. Creating great software is a journey, not a destination.
 * Product decisions are made [in alignment with our core philosophy](https://make.wordpress.org/cli/handbook/philosophy/).
-* [Code review is an integral part of our development workflow](https://make.wordpress.org/cli/handbook/code-review/). Pull requests need approval of at least one other committer before merging. If you’d like more than one code review, please don’t hesitate to request one. You can request a review from a specific person, or from the `@wp-cli/committers` team.
+* [Code review is an integral part of our development workflow](https://make.wordpress.org/cli/handbook/code-review/). Pull requests need the approval of at least one other committer before merging. If you’d like more than one code review, please don’t hesitate to request one. You can request a review from a specific person, or from the `@wp-cli/committers` team.
 * If you need help with something, ask for help. Seriously, ask for help any time you feel like you need help. No sense getting stuck.
 
-## Stellar judgement
+## Stellar judgment
 
-A great product is a reflection of thoughtful, deliberate, and considered decision-making. WP-CLI committers exhibit stellar judgement with making decisions on new features, fixing bugs, merging others pull requests, and generally working on the project.
+A great product is a reflection of thoughtful, deliberate, and considered decision-making. WP-CLI committers exhibit stellar judgment with making decisions on new features, fixing bugs, merging others pull requests, and generally working on the project.
 
 The basis of this decision-making ensures:
 

--- a/installing.md
+++ b/installing.md
@@ -169,7 +169,7 @@ To update everything globally, run `composer global update`.
 
 **Installing a specific version**
 
-If you want to install a specific version of WP-CLI then append the version numbers behind the packages
+If you want to install a specific version of WP-CLI then append the version numbers behind the packages:
 
     composer create-project wp-cli/wp-cli-bundle:2.1.0 --no-dev
 
@@ -226,7 +226,7 @@ You can now use WP-CLI from anywhere in Windows command line.
 
 ### Installing via .deb package
 
-On Debian or Ubuntu, just download and open one of the .deb packages: <https://github.com/wp-cli/builds/tree/gh-pages/deb>
+On Debian or Ubuntu, just download and open one of the .deb packages: <https://github.com/wp-cli/builds/tree/gh-pages/deb>.
 
 
 ### Using a custom PHP binary
@@ -254,4 +254,4 @@ For Composer and Git-based WP-CLI installation, you can alternatively set the `W
 
 ### Installing on MediaTemple
 
-See [http://razorfrog.com/installing-wp-cli-on-mediatemple-grid-server/](http://razorfrog.com/installing-wp-cli-on-mediatemple-grid-server/)
+See [http://razorfrog.com/installing-wp-cli-on-mediatemple-grid-server/](http://razorfrog.com/installing-wp-cli-on-mediatemple-grid-server/).

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -5,14 +5,14 @@ Before you start to report a new issue on the GitHub repository, make sure to ch
 ### How do I get more verbose informations about my WP-CLI installation?
 
 WP-CLI offers the command `wp --info`, which provides you with a lot of information about your WP-CLI install environment. The output will tell you,
-* what operating system and shell you work on
-* which PHP binary is used to run WP-CLI
-* what version of PHP is used
-* where to find WP-CLI's root directory
-* where to find the vendor directory of WP-CLI
-* which WP-CLI binary  you are currently working with (phar path)
-* where WP-CLI packages are stored
-* where to find global and project configuration files for WP-CLI and
+* what operating system and shell you work on.
+* which PHP binary is used to run WP-CLI.
+* what version of PHP is used.
+* where to find WP-CLI's root directory.
+* where to find the vendor directory of WP-CLI.
+* which WP-CLI binary  you are currently working with (phar path).
+* where WP-CLI packages are stored.
+* where to find global and project configuration files for WP-CLI and.
 * which version of WP-CLI you use.
 
 ### What should I do, before I start debugging issues?


### PR DESCRIPTION
If I am not wrong I have changed "install" to "installation" and I think it's documentation word. I have referred this ticket for these changes.

https://core.trac.wordpress.org/ticket/41620