### PR TITLE
Add MinHost hosting-companies.md

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -30,6 +30,7 @@ In alphabetical order:
 * [lima-city](https://www.lima-city.de/webhosting/wordpress)
 * [Liquid Web](https://liquidweb.com/wordpress)
 * [Media Temple](http://mediatemple.net)
+* [MinHost](https://minhost.no)
 * [Mittwald](https://www.mittwald.de/)
 * [Monarobase](https://monarobase.net/wordpress)
 * [NameHero](https://www.namehero.com)


### PR DESCRIPTION
We have now installed WP-CLI as default on all servers, and they are available out-of-the-box when they SSH into their webhotell and use the wp command.