### PR TITLE
Update global configuration parameters URL.

### DIFF
--- a/internal-api/wp-cli-get-config.md
+++ b/internal-api/wp-cli-get-config.md
@@ -19,7 +19,7 @@ Get values of global configuration parameters.
 ## Notes
 
 Provides access to `--path=<path>`, `--url=<url>`, and other values of
-the [global configuration parameters](https://wp-cli.org/config/).
+the [global configuration parameters](https://make.wordpress.org/cli/handbook/config/#global-parameters).
 
 ```
 WP_CLI::log( 'The --url=<url> value is: ' . WP_CLI::get_config( 'url' ) );


### PR DESCRIPTION
Hello Team,

I have updated **global configuration parameters** to https://make.wordpress.org/cli/handbook/config/#global-parameters . Old URL was going to 404 Page.

Kindly review it.

Thanks