### PR TITLE
Added Zenith Media Canada

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -59,6 +59,7 @@ In alphabetical order:
 * [WPEngine.com](http://wpengine.com)
 * [XEL](https://xel.nl)
 * [Zenbox](https://zenbox.pl)
+* [Zenith Media Canada](https://zenithmedia.ca)
 
 The following is a list of hosting companies that use WP-CLI, whereby their customers can write and request the running of standard and custom WP-CLI commands:
 


### PR DESCRIPTION
Zenith Media Canada offers wp-cli on all their client web facing servers as part of an ongoing effort to support the WordPress framework.

As the system admin I've added wp-cli to our core web server deployment script.