### PR TITLE
Add a link in the Option Update page of the Handbook to the Option Reference page in the Codex

### DIFF
--- a/commands/option/update.md
+++ b/commands/option/update.md
@@ -58,6 +58,8 @@ options:
     $ wp option update timezone_string "America/New_York"
     Success: Updated 'timezone_string' option.
 
+You can find a list of keys in the [Option Reference](https://codex.wordpress.org/Option_Reference) page of the WordPress Codex.
+
 ### GLOBAL PARAMETERS
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.


### PR DESCRIPTION
Adding link to Option Reference page as referenced in https://github.com/wp-cli/entity-command/issues/157