### PR TITLE
Adding Veerotech to hosting-companies.md

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -57,6 +57,7 @@ In alphabetical order:
 * [Titibate](https://titibate.com/)
 * [TrulyWP](https://trulywp.com/)
 * [TVC.Net](http://TVC.Net/)
+* [Veerotech](https://www.veerotech.net/)
 * [Voteq - Website Solutions](https://voteq.co.uk/)
 * [WooCart](https://woocart.com)
 * [WPEngine.com](http://wpengine.com)


### PR DESCRIPTION
Adding Veerotech (https://www.veerotech.net/) as they have WordPress CLI preinstalled on all the plans.