### PR TITLE
Adding examples for updating multiple posts

### DIFF
--- a/commands/post/update.md
+++ b/commands/post/update.md
@@ -103,6 +103,17 @@ Updates one or more existing posts.
     # Update a post with multiple meta values.
     $ wp post update 123 --meta_input='{"key1":"value1","key2":"value2"}'
     Success: Updated post 123.
+    
+    # Update multiple posts at once.
+    $ wp post update 123 456 --post_author=789
+    Success: Updated post 123.
+    Success: Updated post 456.
+    
+    # Update all posts of a given post type at once.
+    $ wp post update $(wp post list --post_type=page --format=ids) --post_author=123
+    Success: Updated post 123.
+    Success: Updated post 456.
+    ...
 
 ### GLOBAL PARAMETERS
 


### PR DESCRIPTION
Besides `post delete` has examples of working with multiple posts at the same time, it was not clear that `post update` could do the same.