### PR TITLE
Example to delete in batches of 100

### DIFF
--- a/commands/user/delete.md
+++ b/commands/user/delete.md
@@ -28,6 +28,9 @@ On multisite, `wp user delete` only removes the user from the current site. Incl
     $ wp user delete $(wp user list --role=contributor --field=ID) --reassign=2
     Success: Removed user 813 from http://example.com
     Success: Removed user 578 from http://example.com
+    
+    # Delete all contributors in batches of 100 (avoid error: argument list too long: wp)
+    $ wp user delete $(wp user list --role=contributor --field=ID | head -n 100)
 
 ### GLOBAL PARAMETERS
 


### PR DESCRIPTION
Hey, I faced many times the error _argument list too long: wp_ when deleting users on my sites.

This shows how to delete users in batches of 100.