### PR TITLE
Fixed incomplete docs on ASCII formatting.

### DIFF
--- a/internal-api/wp-cli-utils-ispiped.md
+++ b/internal-api/wp-cli-utils-ispiped.md
@@ -17,15 +17,23 @@ Checks whether the output of the current script is a TTY or a pipe / redirect
 
 ## Notes
 
-Returns true if STDOUT output is being redirected to a pipe or a file; false is
+Returns `true` if `STDOUT` output is being redirected to a pipe or a file; `false` is
 output is being sent directly to the terminal.
 
-If an env variable SHELL_PIPE exists, returned result depends on its
-value. Strings like 1, 0, yes, no, that validate to booleans are accepted.
+If an env variable `SHELL_PIPE` exists, the returned result depends on its
+value. Strings like `1`, `0`, `yes`, `no` that validate to booleans are accepted.
 
 To enable ASCII formatting even when the shell is piped, use the
-ENV variable SHELL_PIPE=0.
+ENV variable `SHELL_PIPE=0`.
+```
+SHELL_PIPE=0 wp plugin list | cat
+```
 
+Note that the db command forwards to the mysql client, which is unaware of the env
+variable. For db commands, pass the `--table` option instead.
+```
+wp db query --table "SELECT 1" | cat
+```
 
 *Internal API documentation is generated from the WP-CLI codebase on every release. To suggest improvements, please submit a pull request.*
 


### PR DESCRIPTION
Problem
- The `SHELL_PIPE` env variable does not work for the db command.

Proposed solution
1. Clarify docs for how to retain ASCII table formatting with the db command.
2. Clarify docs for how to use the env variable, because not all users understand how env variables are specified; the only correct example I found was in the original issue https://github.com/wp-cli/wp-cli/issues/1102.
