### PR TITLE
Typo fixed on https://make.wordpress.org/cli/handbook/guides/installing/

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -122,7 +122,7 @@ Just follow the normal [installation instructions](/#install), except change the
 
 **As part of a project**
 
-Add the following line to your projects `composer.json` file:
+Add the following line to your project's `composer.json` file:
 
     "require" : {
     	"wp-cli/wp-cli-bundle": "*"


### PR DESCRIPTION
Fixes https://github.com/wp-cli/handbook/issues/418 
Apostrophe added for the word : projects. 