### PR TITLE
Add Rocket.net to hosting company list

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -58,6 +58,7 @@ In alphabetical order:
 * [Pagely](https://pagely.com/)
 * [Pantheon](https://pantheon.io)
 * [Pressjitsu](https://pressjitsu.com)
+* [Rocket.net](https://rocket.net)
 * [RoseHosting](https://www.rosehosting.com)
 * [Savvii](https://www.savvii.com/)
 * [ScanNet](https://www.scannet.dk)


### PR DESCRIPTION
Hi! Adding Rocket.net to this list of awesome hosting providers. wp-cli is enabled by default on every site and is one of our favorite utilities :)