### PR TITLE
Corrected local jumplinks

### DIFF
--- a/running-commands-remotely.md
+++ b/running-commands-remotely.md
@@ -137,8 +137,8 @@ Another way to achieve this is to specify the `$PATH` in the remote machine user
 ### Remote non-interactive shell resolves aliases and runs wp as alias with php
 
 Some webhosts are configured very restrictive:
-- They do not allow you to execute your own shellscripts, so everything from method [WP-CLI binary](#copy-wp-cli-binary-to-home--bin) fails.
-- `sshd` is configured with `PermitUserEnvironment=no`, so customizing [~/.ssh/environment](#specify-the-path-in-home--ssh--environment) has no effect and fails too.
+- They do not allow you to execute your own shellscripts, so everything from method [WP-CLI binary](#copy-wp-cli-binary-to-home-bin) fails.
+- `sshd` is configured with `PermitUserEnvironment=no`, so customizing [~/.ssh/environment](#specify-the-path-in-home-ssh-environment) has no effect and fails too.
 - Also [using the before_ssh hook on the client machine](#using-before_ssh-hook-on-client-machine) will not help you, as in all cases you cannot run `wp` on the remote.
 
 The solution: On the remote configure `~/.bashrc` like this:


### PR DESCRIPTION
- The "Preview" in the Github web app Markdown editor produces some anchor links with two consecutive minus characters in them, whereas on the final output website all anchor links have uniformly at maximum only one minus (which I deem better anyhow)
- Corrected acordingly, on the next push to the live website the internal jumplinks should work too then.