### PR TITLE
Add maintainer expectations to the Governance page

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -18,7 +18,13 @@ On occasion, we [grant write access to contributors](https://github.com/orgs/wp-
 
 Becoming a committer can seem glamorous, but it also comes with expectations of responsibility, commitment, and humility.
 
-[andreascreten](https://github.com/andreascreten) is the original author of WP-CLI. [scribu](https://github.com/scribu) and [danielbachhuber](https://github.com/danielbachhuber) have been long time maintainers.
+[andreascreten](https://github.com/andreascreten) is the original author of WP-CLI. [scribu](https://github.com/scribu) and [danielbachhuber](https://github.com/danielbachhuber) have been long time maintainers. [schlessera](https://github.com/schlessera) is the current maintainer.
+
+The maintainer is the person most directly responsible for the reliability and longevity of the project. They are expected to:
+* Hold WP-CLI's overall quality in the utmost regard.
+* Refine the project's vision and direction, and make sure it's understood by all.
+* Enable everyone from new users to experienced committers.
+* Take care of the boring day-to-day work (keeping CI passing, triaging new issues, etc.).
 
 ## What's the connection between WP-CLI and WordPress?
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5719

Synthesized from these meeting notes:
> Alain:
> * Taking care of the boring stuff (e.g. tests are passing, CI pipeline works as expected)
> * Provide onboarding help, answer questions, unblock things.
> * Provide direction for the project (what will and won’t be accepted as contributors)
> * Market and create excitement for the project (e.g. leading Contributor Days)
> * Ensure the longevity and integrity of the project
> * Saying hello to users
>
> Pascal:
> * To be around for people (e.g. office hours). Helps prevent people from thinking the project is dead.
> * Steering technical direction (e.g. code reviews).
> * Elevating people through the contribution pipe
>
> Daniel:
> * Being the final authority on and shipping releases.
> * Regular involvement (min avg 1-2 hours/week) and responsiveness (24-48 business hours)
> * High level: quality and stability of the product.
> * If a severe bug or regression is found, owning the delivery of a patch release.


