### PR TITLE
Add DataPerk to list of hosting companies

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -17,6 +17,7 @@ In alphabetical order:
 * [Curanet](https://curanet.dk)
 * [D9 Hosting](https://d9.hosting)
 * [DanDomain](https://dandomain.dk)
+* [DataPerk](https://dataperk.com)
 * [Dhosting.pl](https://dhosting.pl/)
 * [dinahosting](https://dinahosting.com/)
 * [Dreamhost](http://dreamhost.com)


### PR DESCRIPTION
All of DataPerk's Web servers have WP-CLI installed and available to customers via SSH.