### PR TITLE
Fix: Replacement added for the &amp;&amp;

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -434,6 +434,7 @@ EOT;
 			$docs = preg_replace( '/&quot;/', '"', $docs );
 			$docs = preg_replace( '/wp&gt; /', 'wp> ', $docs );
 			$docs = preg_replace( '/=&gt;/', '=>', $docs );
+			$docs = preg_replace( '/ &amp;&amp; /', ' && ', $docs );
 
 			$global_parameters = <<<EOT
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.

--- a/commands/package/path.md
+++ b/commands/package/path.md
@@ -16,7 +16,7 @@ If you want to contribute to a package, this is a great way to jump to it.
     /home/person/.wp-cli/packages/
 
     # Change directory to package path
-    $ cd $(wp package path) &amp;&amp; pwd
+    $ cd $(wp package path) && pwd
     /home/vagrant/.wp-cli/packages
 
 ### GLOBAL PARAMETERS

--- a/commands/plugin/path.md
+++ b/commands/plugin/path.md
@@ -12,7 +12,7 @@ Gets the path to a plugin or to the plugin directory.
 
 ### EXAMPLES
 
-    $ cd $(wp plugin path) &amp;&amp; pwd
+    $ cd $(wp plugin path) && pwd
     /var/www/wordpress/wp-content/plugins
 
 ### GLOBAL PARAMETERS

--- a/commands/transient/delete.md
+++ b/commands/transient/delete.md
@@ -41,7 +41,7 @@ For a more complete explanation of the transient cache, including the network|si
     Success: 2 transients deleted from the database.
 
     # Delete all transients in a multsite.
-    $ wp transient delete --all --network &amp;&amp; wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
+    $ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
 
 ### GLOBAL PARAMETERS
 


### PR DESCRIPTION
Issue: https://github.com/wp-cli/cache-command/issues/60
```
$ wp transient delete --all --network &amp;&amp; wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all

Should be:
$ wp transient delete --all --network && wp site list --field=url | xargs -n1 -I % wp --url=% transient delete --all
```

**Resolved**

- ` &amp;&amp; ` will properly converted into ` && `