### PR TITLE
Fix multisite search-replace example

### DIFF
--- a/commands/search-replace.md
+++ b/commands/search-replace.md
@@ -103,7 +103,7 @@ options:
     $ wp search-replace '\[foo id="([0-9]+)"' '[bar id="\1"' --regex --regex-flags='i'
 
     # Turn your production multisite database into a local dev database
-    $ wp search-replace --url=example.com example.com example.test 'wp_*options' wp_blogs --all-tables
+    $ wp search-replace --url=example.com example.com example.test 'wp_*options' wp_blogs wp_site --network
 
     # Search/replace to a SQL file without transforming the database
     $ wp search-replace foo bar --export=database.sql

--- a/commands/search-replace.md
+++ b/commands/search-replace.md
@@ -103,7 +103,7 @@ options:
     $ wp search-replace '\[foo id="([0-9]+)"' '[bar id="\1"' --regex --regex-flags='i'
 
     # Turn your production multisite database into a local dev database
-    $ wp search-replace --url=example.com example.com example.test 'wp_*options' wp_blogs
+    $ wp search-replace --url=example.com example.com example.test 'wp_*options' wp_blogs --all-tables
 
     # Search/replace to a SQL file without transforming the database
     $ wp search-replace foo bar --export=database.sql


### PR DESCRIPTION
Adds the `--network` flag and the `wp_site` table to the example about how to prepare a multisite for local development:
- Without the `--network` flag, the wildcard in the example for performing a search-replace across all options tables for all subsites fails to match subsite options tables and only matches the main options table (e.g., `wp_options`).
- Without the `wp_site` table, the search-replace for domains is incomplete if targeting the primary site.