### PR TITLE
Update GitHub links to use search endpoint instead

### DIFF
--- a/bug-reports.md
+++ b/bug-reports.md
@@ -4,7 +4,7 @@ Think you've found a bug? We'd love for you to help us get it fixed.
 
 Before you create a new issue, you should:
 
-* [Search existing issues](https://github.com/issues?utf8=%E2%9C%93&q=sort%3Aupdated-desc+org%3Awp-cli+label%3Abug) to see if there's an existing resolution to it, or if it's already been fixed in a newer version.
+* [Search existing issues](https://github.com/search?q=org%3Awp-cli+label%3Abug+is%3Aopen+sort%3Aupdated-desc&type=issues) to see if there's an existing resolution to it, or if it's already been fixed in a newer version.
 * Check our documentation on [common issues and their fixes](https://make.wordpress.org/cli/handbook/common-issues/). It's worth reading through the GitHub issues linked on the page, as the error listed may not be exactly the error you're experiencing.
 * Reproduce the issue in a fresh installation of WordPress (e.g. Twenty Sixteen or similar, with no plugins active). If the issue only reproduces in a custom environment, then the issue is a bug in your environment, not WP-CLI (make sure `WP_DEBUG` is enabled, which will often give you more visibility into the issue). You may be able to [track down the error to a specific plugin or theme](https://make.wordpress.org/cli/handbook/identify-plugin-theme-conflict/).
 

--- a/contributing.md
+++ b/contributing.md
@@ -20,7 +20,7 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 
 Think you’ve found a bug? We’d love for you to help us get it fixed.
 
-Before you create a new issue, you should [search existing issues](https://github.com/issues?utf8=%E2%9C%93&q=sort%3Aupdated-desc+org%3Awp-cli+label%3Abug) to see if there’s an existing resolution to it, or if it’s already been fixed in a newer version of WP-CLI. You should also check our [documentation on common issues and their fixes](https://make.wordpress.org/cli/handbook/common-issues/).
+Before you create a new issue, you should [search existing issues](https://github.com/search?q=org%3Awp-cli+label%3Abug+is%3Aopen+sort%3Aupdated-desc&type=issues) to see if there’s an existing resolution to it, or if it’s already been fixed in a newer version of WP-CLI. You should also check our [documentation on common issues and their fixes](https://make.wordpress.org/cli/handbook/common-issues/).
 
 Once you’ve done a bit of searching and discovered there isn’t an open or fixed issue for your bug, please [follow our guidelines for submitting a bug report](https://make.wordpress.org/cli/handbook/bug-reports/) to make sure it gets addressed in a timely manner.
 
@@ -34,7 +34,7 @@ Once you've decided to commit the time to seeing your pull request through, plea
 
 ### Improving our documentation
 
-Is documentation your strength? Take a look at the currently open [documentation issues](https://github.com/issues?q=is%3Aopen+sort%3Aupdated-desc+org%3Awp-cli+label%3Ascope%3Adocumentation) and see if you can tackle any of those.
+Is documentation your strength? Take a look at the currently open [documentation issues](https://github.com/search?q=org%3Awp-cli+label%3Ascope%3Adocumentation+is%3Aopen+sort%3Aupdated-desc&type=issues) and see if you can tackle any of those.
 
 There are a couple different types of documentation currently part of WP-CLI:
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -2,7 +2,7 @@
 
 WP-CLI follows a pull request workflow for changes to its code (and documentation). Whether you want to fix a bug or implement a new feature, the process is pretty much the same:
 
-0. [Search existing issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+sort%3Aupdated-desc+org%3Awp-cli); if you can't find anything related to what you want to work on, open a new issue in the appropriate repository so that you can get some initial feedback.
+0. [Search existing issues](https://github.com/search?q=org%3Awp-cli+is%3Aopen+sort%3Aupdated-desc&type=issues); if you can't find anything related to what you want to work on, open a new issue in the appropriate repository so that you can get some initial feedback.
     1. Opening an issue before submitting a pull request helps us provide architectural and implementation guidance before you spend too much time on the code.
 1. Fork the repository you'd like to modify, either the framework or one of the command packages.
     1. See [Setting Up](#setting-up) for more details on configuring the codebase for development.

--- a/repository-management.md
+++ b/repository-management.md
@@ -178,6 +178,6 @@ There are a lot of useful ways to search GitHub. These searches can be put into 
 
 Here are some examples:
 
-* [Open issues & pull requests across all WP-CLI repositories, sorted by last updated](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+sort%3Aupdated-desc+org%3Awp-cli)
-* [Merged pull requests across all WP-CLI repositories that have no milestone, sorted by last updated](https://github.com/issues?utf8=%E2%9C%93&q=is%3Amerged+no%3Amilestone+sort%3Aupdated-desc+org%3Awp-cli+)
-* [Closed issues & pull requests across all WP-CLI repositories that have no label, sorted by last updated](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aclosed+no%3Alabel+sort%3Aupdated-desc+org%3Awp-cli+)
+* [Open issues & pull requests across all WP-CLI repositories, sorted by last updated](https://github.com/search?q=org%3Awp-cli+is%3Aopen+sort%3Aupdated-desc&type=issues)
+* [Merged pull requests across all WP-CLI repositories that have no milestone, sorted by last updated](https://github.com/search?q=org%3Awp-cli+is%3Amerged+no%3Amilestone+sort%3Aupdated-desc&type=issues)
+* [Closed issues & pull requests across all WP-CLI repositories that have no label, sorted by last updated](https://github.com/search?q=org%3Awp-cli+is%3Aclosed+no%3Alabel+sort%3Aupdated-desc&type=issues)

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -86,7 +86,7 @@ Additionally you can use WP-CLI's global parameter `--debug` to show all PHP err
 
 If you think you’ve found a bug, we’d love to hear from you to get it fixed.
 
-Bug reporting for WP-CLI is handled on GitHub. Before you create a new issue, please [search existing issues](https://github.com/issues?utf8=%E2%9C%93&q=sort%3Aupdated-desc+org%3Awp-cli+label%3Abug) to see if there’s an existing resolution to it. If there isn’t an open or fixed issue for your bug, please [follow our guidelines for submitting a bug report](https://make.wordpress.org/cli/handbook/bug-reports/) to make sure it gets addressed in a timely manner. Providing the summary, steps to reproduce, environmental details, and other specifics identified below will help guarantee you are submitting a full bug report.
+Bug reporting for WP-CLI is handled on GitHub. Before you create a new issue, please [search existing issues](https://github.com/search?q=org%3Awp-cli+label%3Abug+is%3Aopen+sort%3Aupdated-desc&type=issues) to see if there’s an existing resolution to it. If there isn’t an open or fixed issue for your bug, please [follow our guidelines for submitting a bug report](https://make.wordpress.org/cli/handbook/bug-reports/) to make sure it gets addressed in a timely manner. Providing the summary, steps to reproduce, environmental details, and other specifics identified below will help guarantee you are submitting a full bug report.
 
 Please provide us with:
 * a summary of the issue in narrative form,


### PR DESCRIPTION
In this pull request I am updating the GitHub links to use the `/search/` endpoint instead of `/issues` which is not usable by logged out users. See #452 for full context.

Resolves #452.