### PR TITLE
Fix handbook manifest JSON corruption

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -47,7 +47,6 @@
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/contributor-day.md",
         "parent": null
     },
-    },
     "doctor-check-constant-value": {
         "title": "Write a check for asserting the value of a given constant",
         "slug": "doctor-check-constant-value",


### PR DESCRIPTION
The PR https://github.com/wp-cli/handbook/pull/456/ introduced a corruption in the JSON braces, making the sync error out.