### PR TITLE
Hack Day: Add information about the open video sessions

### DIFF
--- a/contributor-day.md
+++ b/contributor-day.md
@@ -12,6 +12,15 @@ Your leads for the day are: [schlessera](https://github.com/schlessera), [daniel
 
 A few seasoned WP-CLI contributors are also helping out: TBD
 
+## Open Video Sessions
+
+During the Hack Day, we’ll have two open video chat sessions:
+
+- From 🕓 08:00 WET to 09:00 WET
+- From 🕓 15:00 WET to 16:00 WET
+
+These sessions are a great opportunity to discuss remaining issues live, chat about the progress we’ve made, and to connect with the community. Feel free to join these to talk through any challenges or share your updates!
+
 ## Getting Started
 
 If you normally use WP-CLI on your web host or via Brew, you're most likely using the Phar executable (`wp-cli.phar`). This Phar executable file is the "built", singular version of WP-CLI. It is compiled from a couple dozen repositories in the WP-CLI GitHub organization.

--- a/contributor-day.md
+++ b/contributor-day.md
@@ -16,8 +16,8 @@ A few seasoned WP-CLI contributors are also helping out: TBD
 
 During the Hack Day, we’ll have two open video chat sessions:
 
-- From 🕓 08:00 WET to 09:00 WET
-- From 🕓 15:00 WET to 16:00 WET
+- From 🕓 00:00-01:00 PST / 03:00-04:00 EST / 08:00-07:00 UTC /  09:00-10:00 CET / 17:00-18:00 JST
+- From 🕓 07:00-08:00 PST / 10:00-11:00 EST / 15:00-16:00 UTC / 16:00-17:00 CET / 00:00-01:00 JST
 
 These sessions are a great opportunity to discuss remaining issues live, chat about the progress we’ve made, and to connect with the community. Feel free to join these to talk through any challenges or share your updates!
 

--- a/contributor-day.md
+++ b/contributor-day.md
@@ -16,7 +16,7 @@ A few seasoned WP-CLI contributors are also helping out: TBD
 
 During the Hack Day, we’ll have two open video chat sessions:
 
-- [🕓 00:00-01:00 PST / 03:00-04:00 EST / 08:00-07:00 UTC / 09:00-10:00 CET / 17:00-18:00 JST](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20231110T0800)
+- [🕓 00:00-01:00 PST / 03:00-04:00 EST / 08:00-09:00 UTC / 09:00-10:00 CET / 17:00-18:00 JST](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20231110T0800)
 - [🕓 07:00-08:00 PST / 10:00-11:00 EST / 15:00-16:00 UTC / 16:00-17:00 CET / 00:00-01:00 JST](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20231110T1500)
 
 These sessions are a great opportunity to discuss remaining issues live, chat about the progress we’ve made, and to connect with the community. Feel free to join these to talk through any challenges or share your updates!

--- a/contributor-day.md
+++ b/contributor-day.md
@@ -16,8 +16,8 @@ A few seasoned WP-CLI contributors are also helping out: TBD
 
 During the Hack Day, we’ll have two open video chat sessions:
 
-- From 🕓 00:00-01:00 PST / 03:00-04:00 EST / 08:00-07:00 UTC /  09:00-10:00 CET / 17:00-18:00 JST
-- From 🕓 07:00-08:00 PST / 10:00-11:00 EST / 15:00-16:00 UTC / 16:00-17:00 CET / 00:00-01:00 JST
+- [🕓 00:00-01:00 PST / 03:00-04:00 EST / 08:00-07:00 UTC / 09:00-10:00 CET / 17:00-18:00 JST](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20231110T0800)
+- [🕓 07:00-08:00 PST / 10:00-11:00 EST / 15:00-16:00 UTC / 16:00-17:00 CET / 00:00-01:00 JST](https://www.timeanddate.com/worldclock/fixedtime.html?iso=20231110T1500)
 
 These sessions are a great opportunity to discuss remaining issues live, chat about the progress we’ve made, and to connect with the community. Feel free to join these to talk through any challenges or share your updates!
 


### PR DESCRIPTION
- Related https://github.com/wp-cli/wp-cli/issues/5856

# Description

I think adding a the information about the time when the open video sessions will occur is key.