### PR TITLE
Hack Day: Remove line deleted line

### DIFF
--- a/contributor-day.md
+++ b/contributor-day.md
@@ -10,8 +10,6 @@ We put together this guide to make contributing as straightforward as possible. 
 
 Your leads for the day are: [schlessera](https://github.com/schlessera), [danielbachhuber](https://github.com/danielbachhuber), [swissspidy](https://github.com/swissspidy)
 
-A few seasoned WP-CLI contributors are also helping out: TBD
-
 ## Open Video Sessions
 
 During the Hack Day, we’ll have two open video chat sessions:


### PR DESCRIPTION
# Description

- On https://github.com/wp-cli/handbook/pull/473,  I introduced a line that was removed on https://github.com/wp-cli/handbook/pull/474 due to an error while resolving a merge conflict.
Let's remove it again.