### PR TITLE
Fix handbook generation when Phar is used directly

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -196,7 +196,6 @@ EOT;
 					$filename = $reflection_func->getFileName();
 				}
 			}
-			var_dump( $filename );
 			if ( $filename ) {
 				preg_match( '#(?:vendor/wp-cli/|wp-cli-dev/)([^/]+)#', $filename, $matches );
 				if ( ! empty( $matches[1] ) ) {

--- a/bin/command.php
+++ b/bin/command.php
@@ -196,8 +196,9 @@ EOT;
 					$filename = $reflection_func->getFileName();
 				}
 			}
+			var_dump( $filename );
 			if ( $filename ) {
-				preg_match( '#wp-cli-dev/([^/]+)#', $filename, $matches );
+				preg_match( '#(?:vendor/wp-cli/|wp-cli-dev/)([^/]+)#', $filename, $matches );
 				if ( ! empty( $matches[1] ) ) {
 					$repo_url = 'https://github.com/wp-cli/' . $matches[1];
 				}

--- a/bin/commands-manifest.json
+++ b/bin/commands-manifest.json
@@ -1647,38 +1647,6 @@
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/child-theme.md",
         "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-command"
     },
-    "scaffold\/package-github": {
-        "title": "scaffold package-github",
-        "slug": "package-github",
-        "cmd_path": "scaffold\/package-github",
-        "parent": "scaffold",
-        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package-github.md",
-        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
-    },
-    "scaffold\/package-readme": {
-        "title": "scaffold package-readme",
-        "slug": "package-readme",
-        "cmd_path": "scaffold\/package-readme",
-        "parent": "scaffold",
-        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package-readme.md",
-        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
-    },
-    "scaffold\/package-tests": {
-        "title": "scaffold package-tests",
-        "slug": "package-tests",
-        "cmd_path": "scaffold\/package-tests",
-        "parent": "scaffold",
-        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package-tests.md",
-        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
-    },
-    "scaffold\/package": {
-        "title": "scaffold package",
-        "slug": "package",
-        "cmd_path": "scaffold\/package",
-        "parent": "scaffold",
-        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package.md",
-        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
-    },
     "scaffold\/plugin-tests": {
         "title": "scaffold plugin-tests",
         "slug": "plugin-tests",

--- a/bin/commands-manifest.json
+++ b/bin/commands-manifest.json
@@ -1647,6 +1647,38 @@
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/child-theme.md",
         "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-command"
     },
+    "scaffold\/package-github": {
+        "title": "scaffold package-github",
+        "slug": "package-github",
+        "cmd_path": "scaffold\/package-github",
+        "parent": "scaffold",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package-github.md",
+        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
+    },
+    "scaffold\/package-readme": {
+        "title": "scaffold package-readme",
+        "slug": "package-readme",
+        "cmd_path": "scaffold\/package-readme",
+        "parent": "scaffold",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package-readme.md",
+        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
+    },
+    "scaffold\/package-tests": {
+        "title": "scaffold package-tests",
+        "slug": "package-tests",
+        "cmd_path": "scaffold\/package-tests",
+        "parent": "scaffold",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package-tests.md",
+        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
+    },
+    "scaffold\/package": {
+        "title": "scaffold package",
+        "slug": "package",
+        "cmd_path": "scaffold\/package",
+        "parent": "scaffold",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/commands\/scaffold\/package.md",
+        "repo_url": "https:\/\/github.com\/wp-cli\/scaffold-package-command"
+    },
     "scaffold\/plugin-tests": {
         "title": "scaffold plugin-tests",
         "slug": "plugin-tests",

--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -42,7 +42,7 @@
         "parent": null
     },
     "contributor-day": {
-        "title": "WordCamp Contributor Day",
+        "title": "WP-CLI Hack Day",
         "slug": "contributor-day",
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/contributor-day.md",
         "parent": null

--- a/commands/dist-archive.md
+++ b/commands/dist-archive.md
@@ -41,7 +41,10 @@ options:
 \---
 
 [\--filename-format=&lt;filename-format&gt;]
-: Use a custom format for archive filename. Defaults to '{name}.{version}'. This is ignored if a custom filename is provided or version does not exist.
+: Use a custom format for archive filename. Available substitutions: {name}, {version}. This is ignored if the &lt;target&gt; parameter is provided or the version cannot be determined.
+\---
+default: "{name}.{version}"
+\---
 
 ### GLOBAL PARAMETERS
 

--- a/internal-api/wp-cli-utils-http-request.md
+++ b/internal-api/wp-cli-utils-http-request.md
@@ -11,6 +11,7 @@ Make a HTTP request to a remote URL.
 <div>
 <strong>$method</strong> (string) HTTP method (GET, POST, DELETE, etc.).<br />
 <strong>$url</strong> (string) URL to make the HTTP request to.<br />
+<strong>$data</strong> (array|null) Data to send either as a query string for GET/HEAD requests,<br />
 <strong>$headers</strong> (array) Add specific headers to the request.<br />
 <strong>$options</strong> (array) {<br />    Optional. An associative array of additional request options.<br />    @type bool $halt_on_error Whether or not command execution should be halted on error. Default: true<br />    @type bool|string $verify A boolean to use enable/disable SSL verification<br />                              or string absolute path to CA cert to use.<br />                              Defaults to detected CA cert bundled with the Requests library.<br />    @type bool $insecure      Whether to retry automatically without certificate validation.<br />}<br />
 <strong>@return</strong> (object) <br />
@@ -31,6 +32,7 @@ if ( 20 != substr( $md5_response->status_code, 0, 2 ) ) {
      WP_CLI::error( "Couldn't access md5 hash for release (HTTP code {$response->status_code})" );
 }
 ```
+                           or in the body for POST requests.
 
 
 *Internal API documentation is generated from the WP-CLI codebase on every release. To suggest improvements, please submit a pull request.*


### PR DESCRIPTION
In the case where the handbook generation is triggered via anything else than the `wp-cli-dev` environment, the script was broken and did not correctly recognize the `$repo_url`.

This change fixes this to make sure packages are correctly identified from within a `vendor` folder.