### PR TITLE
Add note about multisite usage in `wp db query` docs

### DIFF
--- a/commands/db/query.md
+++ b/commands/db/query.md
@@ -60,6 +60,29 @@ Use the `--skip-column-names` MySQL argument to exclude the headers from a SELEC
     | 2 | home | http://wordpress-develop.dev | yes |
     +---+------+------------------------------+-----+
 
+### MULTISITE USAGE
+
+Please note that the global `--url` parameter will have no effect on this command.
+In order to query for data in a site other than your primary site,
+you will need to manually modify the table names to use the prefix that includes the site's ID.
+
+For example, to get the `home` option for your second site, modify the example above like so:
+
+    $ wp db query 'SELECT option_value FROM wp_2_options WHERE option_name="home"' --skip-column-names
+    +----------------------+
+    | https://example2.com |
+    +----------------------+
+
+To confirm the ID for the site you want to query, you can use the `wp site list` command:
+
+    # wp site list --fields=blog_id,url
+    +---------+-----------------------+
+    | blog_id | url                   |
+    +---------+-----------------------+
+    | 1       | https://example1.com/ |
+    | 2       | https://example2.com/ |
+    +---------+-----------------------+
+
 ### GLOBAL PARAMETERS
 
 These [global parameters](https://make.wordpress.org/cli/handbook/config/) have the same behavior across all commands and affect how WP-CLI interacts with WordPress.
@@ -67,7 +90,7 @@ These [global parameters](https://make.wordpress.org/cli/handbook/config/) have 
 | **Argument**    | **Description**              |
 |:----------------|:-----------------------------|
 | `--path=<path>` | Path to the WordPress files. |
-| `--url=<url>` | Pretend request came from given URL. In multisite, this argument is how the target site is specified. |
+| `--url=<url>` | Pretend request came from given URL. In multisite, this argument is how the target site is specified. **Note:** Has no effect on this command. |
 | `--ssh=[<scheme>:][<user>@]<host\|container>[:<port>][<path>]` | Perform operation against a remote server over SSH (or a container using scheme of "docker", "docker-compose", "docker-compose-run", "vagrant"). |
 | `--http=<http>` | Perform operation against a remote WordPress installation over HTTP. |
 | `--user=<id\|login\|email>` | Set the WordPress user. |


### PR DESCRIPTION
I was caught out by the fact that the global `--url` parameter, normally used to target a non-primary site in a multisite setup, has no effect on the `wb db query` command, so I thought I'd propose adding a note about it.