### PR TITLE
Fix invalid links from external resources

### DIFF
--- a/external-resources.md
+++ b/external-resources.md
@@ -14,7 +14,7 @@
 
 * [Francesco Laffi: WPday Bologna 2013: wp-cli](https://speakerdeck.com/francescolaffi/wpday-bologna-2013-wp-cli)
 * [Michael Bastos: Command Line WordPress Step by Step](https://docs.google.com/presentation/d/1iDYvmM_52ww_iB4aGMAYL_KJ1pnElAVm40c7IrZtyz8/edit)
-* [Kelly Dwan: Importing (any!) Content with WP-CLI](//redradar.net/slides/wp-cli/)
+* [Kelly Dwan: Importing (any!) Content with WP-CLI](https://www.slideshare.net/slideshow/nerds-2014wpcli/39052931/)
 * [Jaime Martinez: Simplify your day to day tasks with WP-CLI](http://slid.es/jmslbam/wp-cli-wp-meetup010-25-nov-2013)
 
 ## Videos
@@ -22,5 +22,5 @@
 * [scribu: Command Line Learnings For Make Benefit Glorious Nation Of WordPress](http://wordpress.tv/2013/02/23/cristi-burka-command-line-learnings-for-make-benefit-glorious-nation-of-wordpress/)
 * [Mike Schroder: Magical WordPress Management using WP-CLI](http://wordpress.tv/2013/08/06/mike-schroder-magical-wordpress-management-using-wp-cli/)
 * [Daniel Bachhuber: WordPress at the Command Line](http://wordpress.tv/2012/08/21/daniel-bachhuber-wordpress-at-the-command-line/)
-* [AJ Morris: Managing WordPress from the Command Line](http://ajmorris.me/managing-wordpress-command-line/)
+* [AJ Morris: Managing WordPress from the Command Line](https://wordpress.tv/2016/03/26/aj-morris-using-wp-cli-to-create-your-own-managed-wordpress-hosting/)
 * [Shawn Hooper: WP-CLI – Save Time by Managing WordPress from the Command Line](https://wordpress.tv/2015/09/15/shawn-hooper-wp-cli-save-time-managing-command-line/)

--- a/external-resources.md
+++ b/external-resources.md
@@ -2,12 +2,12 @@
 
 ## Blog posts & tutorials
 
-* [scribu: A Command-Line Interface for WordPress](http://scribu.net/wordpress/a-command-line-interface-for-wordpress.html)
-* [madewithlove: WP-CLI: WordPress Command Line Tools](https://madewithlove.com/blog/this-is-madewithlove/wp-cli-wordpress-command-line-tools/)
-* [Mika Epstein: Command Line WP](http://halfelf.org/2012/command-line-wp/)
-* [Treehouse Blog: Tame WordPress from the Command Line with wp-cli](http://blog.teamtreehouse.com/tame-wordpress-from-the-command-line-with-wp-cli)
+* [scribu: A Command-Line Interface for WordPress](https://scribu.net/wordpress/a-command-line-interface-for-wordpress.html)
+* [madewithlove: WP-CLI: WordPress Command Line Tools](https://madewithlove.com/blog/wp-cli-wordpress-command-line-tools/)
+* [Mika Epstein: Command Line WP](https://halfelf.org/2012/command-line-wp/)
+* [Treehouse Blog: Tame WordPress from the Command Line with wp-cli](https://blog.teamtreehouse.com/tame-wordpress-from-the-command-line-with-wp-cli)
 * [Matt Wiebe: Why You Should Develop Plugins With wp-cli](https://mattwiebe.wordpress.com/2014/01/15/why-you-should-develop-plugins-with-wp-cli/)
-* [Torque: Using WP CLI to Set Up a Test Version of Your Site](http://torquemag.io/using-wp-cli-to-set-up-a-test-version-of-your-site/)
+* [Torque: Using WP CLI to Set Up a Test Version of Your Site](https://torquemag.io/using-wp-cli-to-set-up-a-test-version-of-your-site/)
 * [WP Bullet Guides: Useful Bash Scripts Utilizing WP-CLI](https://guides.wp-bullet.com/category/wp-cli/) 
 
 ## Slides
@@ -15,12 +15,12 @@
 * [Francesco Laffi: WPday Bologna 2013: wp-cli](https://speakerdeck.com/francescolaffi/wpday-bologna-2013-wp-cli)
 * [Michael Bastos: Command Line WordPress Step by Step](https://docs.google.com/presentation/d/1iDYvmM_52ww_iB4aGMAYL_KJ1pnElAVm40c7IrZtyz8/edit)
 * [Kelly Dwan: Importing (any!) Content with WP-CLI](https://www.slideshare.net/slideshow/nerds-2014wpcli/39052931/)
-* [Jaime Martinez: Simplify your day to day tasks with WP-CLI](http://slid.es/jmslbam/wp-cli-wp-meetup010-25-nov-2013)
+* [Jaime Martinez: Simplify your day to day tasks with WP-CLI](https://slid.es/jmslbam/wp-cli-wp-meetup010-25-nov-2013)
 
 ## Videos
 
-* [scribu: Command Line Learnings For Make Benefit Glorious Nation Of WordPress](http://wordpress.tv/2013/02/23/cristi-burka-command-line-learnings-for-make-benefit-glorious-nation-of-wordpress/)
-* [Mike Schroder: Magical WordPress Management using WP-CLI](http://wordpress.tv/2013/08/06/mike-schroder-magical-wordpress-management-using-wp-cli/)
-* [Daniel Bachhuber: WordPress at the Command Line](http://wordpress.tv/2012/08/21/daniel-bachhuber-wordpress-at-the-command-line/)
+* [scribu: Command Line Learnings For Make Benefit Glorious Nation Of WordPress](https://wordpress.tv/2013/02/23/cristi-burka-command-line-learnings-for-make-benefit-glorious-nation-of-wordpress/)
+* [Mike Schroder: Magical WordPress Management using WP-CLI](https://wordpress.tv/2013/08/06/mike-schroder-magical-wordpress-management-using-wp-cli/)
+* [Daniel Bachhuber: WordPress at the Command Line](https://wordpress.tv/2012/08/21/daniel-bachhuber-wordpress-at-the-command-line/)
 * [AJ Morris: Managing WordPress from the Command Line](https://wordpress.tv/2016/03/26/aj-morris-using-wp-cli-to-create-your-own-managed-wordpress-hosting/)
 * [Shawn Hooper: WP-CLI – Save Time by Managing WordPress from the Command Line](https://wordpress.tv/2015/09/15/shawn-hooper-wp-cli-save-time-managing-command-line/)


### PR DESCRIPTION
In WP CLI Handbook [External Resources](https://make.wordpress.org/cli/handbook/guides/external-resources/),  there has below invalid links -
#### Slides > [Kelly Dwan: Importing (any!) Content with WP-CLI](//redradar.net/slides/wp-cli/)
#### Videos > [AJ Morris: Managing WordPress from the Command Line](http://ajmorris.me/managing-wordpress-command-line/)

With this PR it should change with below links that should be as below and also change some `http://` resourses ink  -
#### Slides > [Kelly Dwan: Importing (any!) Content with WP-CLI](https://www.slideshare.net/slideshow/nerds-2014wpcli/39052931/)
#### Videos > [AJ Morris: Managing WordPress from the Command Line](https://wordpress.tv/2016/03/26/aj-morris-using-wp-cli-to-create-your-own-managed-wordpress-hosting/)
