### PR TITLE
Removed Invalid Link from WP CLI Handbook

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -29,7 +29,6 @@ In alphabetical order:
 * [Hosting4Agency](https://www.hosting4agency.com/news/wp-cli-come-usarlo/)
 * [Host4Geeks](https://host4geeks.com/managed-wordpress-hosting)
 * [Hosterion](https://www.hosterion.com)
-* [HostGalaxy](https://www.hostgalaxy.com)
 * [HostGator](http://www.hostgator.com)
 * [Hostico](https://hostico.ro)
 * [Hostinger](https://www.hostinger.com)

--- a/tools.md
+++ b/tools.md
@@ -84,13 +84,11 @@ If you implement a WP-CLI command in one of your plugins, please list it here.
 
 * Vim - [https://github.com/dsawardekar/wordpress.vim](https://github.com/dsawardekar/wordpress.vim)
 * Netbeans - [https://github.com/junichi11/netbeans-wordpress-plugin](https://github.com/junichi11/netbeans-wordpress-plugin)
-* Netbeans - [http://plugins.netbeans.org/plugin/46542/php-wordpress-blog-cms](http://plugins.netbeans.org/plugin/46542/php-wordpress-blog-cms)
 
 ## Vagrant boxes
 
 * [Trellis](https://github.com/roots/trellis)
 * [Varying Vagrant Vagrants](https://github.com/Varying-Vagrant-Vagrants/VVV)
-* [VCCW](http://vccw.cc/)
 
 ## Misc
 


### PR DESCRIPTION
In WP CLI Handbook [Hosting Companies](https://make.wordpress.org/cli/handbook/references/hosting-companies/), there is a link with domain expire so I believe it should be removed.

[HostGalaxy](https://www.hostgalaxy.com/)

In WP CLI Handbook [Tools](https://make.wordpress.org/cli/handbook/references/tools/), there is a link which should expire so I believe it should be removed.

[Vagrant boxes](https://make.wordpress.org/cli/handbook/references/tools/#vagrant-boxes) > [VCCW](http://vccw.cc/)

[Editor plugins](https://make.wordpress.org/cli/handbook/references/tools/#editor-plugins) > Netbeans – http://plugins.netbeans.org/plugin/46542/php-wordpress-blog-cms

With this PR it should remove those invalid links.

![image](https://github.com/wp-cli/handbook/assets/32844880/5172d8f3-f29a-4659-aa4f-59c1ecae7eb1)

![image](https://github.com/wp-cli/handbook/assets/32844880/f802c60d-609b-4c38-897c-57c2ca8c6594)



