### PR TITLE
Updating profile.md with more hooks showing for the profile stage command

### DIFF
--- a/commands/profile.md
+++ b/commands/profile.md
@@ -21,15 +21,16 @@ Quickly identify what's slow with WordPress.
     +--------------------------+---------+-------------+
     | hook                     | time    | cache_ratio |
     +--------------------------+---------+-------------+
-    | muplugins_loaded:before  | 0.2335s | 40%         |
-    | muplugins_loaded         | 0.0007s | 50%         |
-    | plugins_loaded:before    | 0.2792s | 77.63%      |
-    | plugins_loaded           | 0.1502s | 100%        |
-    | after_setup_theme:before | 0.068s  | 100%        |
-    | init                     | 0.2643s | 96.88%      |
-    | wp_loaded:after          | 0.0377s |             |
+    | muplugins_loaded:before  | 0.1828s | 33.33%      |
+    | plugins_loaded:before    | 0.0998s | 78.13%      |
+    | plugins_loaded           | 0.0187s | 19.32%      |
+    | setup_theme              | 0.0017s | 75%         |
+    | after_setup_theme:before | 0.0113s | 95.45%      |
+    | after_setup_theme        | 0.0049s | 96%         |
+    | init                     | 0.1417s | 76.74%      |
+    | wp_loaded:after          | 0.0229s |             |
     +--------------------------+---------+-------------+
-    | total (7)                | 1.0335s | 77.42%      |
+    | total (8)                | 0.4837s | 67.71%      |
     +--------------------------+---------+-------------+
 
 


### PR DESCRIPTION
Added with more hooks showing for the `wp profile stage bootstrap --fields=hook,time,cache_ratio --spotlight` like `setup_theme   `and `after_setup_theme`.