### PR TITLE
Added Yoast WP-CLI command to tools.md

### DIFF
--- a/tools.md
+++ b/tools.md
@@ -66,6 +66,7 @@ The following table is an alphabetical list of known commands defined in WordPre
 | updraftplus           | [UpdraftPlus](https://updraftplus.com/)
 | Unsplash              | [Import images from Unsplash into your Media Library](https://github.com/A5hleyRich/wp-cli-unsplash-command)
 | wp2static             | [Generate & deploy a static HTML version of your site](https://github.com/leonstafford/wp2static)
+| yoast                 | [Indexables on Yoast](https://developer.yoast.com/features/wp-cli/reindex-indexables/)
 
 If you implement a WP-CLI command in one of your plugins, please list it here.
 

--- a/tools.md
+++ b/tools.md
@@ -66,7 +66,7 @@ The following table is an alphabetical list of known commands defined in WordPre
 | updraftplus           | [UpdraftPlus](https://updraftplus.com/)
 | Unsplash              | [Import images from Unsplash into your Media Library](https://github.com/A5hleyRich/wp-cli-unsplash-command)
 | wp2static             | [Generate & deploy a static HTML version of your site](https://github.com/leonstafford/wp2static)
-| yoast                 | [Indexables on Yoast](https://developer.yoast.com/features/wp-cli/reindex-indexables/)
+| yoast                 | [Reindex Indexables on Yoast](https://developer.yoast.com/features/wp-cli/reindex-indexables/)
 
 If you implement a WP-CLI command in one of your plugins, please list it here.
 


### PR DESCRIPTION
Added the Yoast WP-CLI command to run the indexation process. More details are available here: https://developer.yoast.com/features/wp-cli/reindex-indexables/

See https://github.com/wp-cli/wp-cli/issues/5955