### PR TITLE
Add sanity check in regenerating doc pages

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -620,7 +620,7 @@ EOT;
 					$ret['description'] .= PHP_EOL . "{$extra_line}{$info}";
 				} else {
 					preg_match( '/@(\w+)/', $info, $matches );
-					$param_name = $matches[1];
+					$param_name = count( $matches ) > 1 ? $matches[1] : null;
 					$value      = str_replace( "@$param_name ", '', $info );
 					if ( ! isset( $ret['parameters'][ $param_name ] ) ) {
 						$ret['parameters'][ $param_name ] = [];


### PR DESCRIPTION
Fixes: https://github.com/wp-cli/handbook/issues/507

- As per the issue, the generation of `internal-api` was failing because of the warnings thrown by the following code.
- The warnings originates from an assumption that `preg_match` would always find a match.
- A sanity check has been added in the `parse_docblock` method to handle invalid JSON output gracefully.