### PR TITLE
Add files autoloader for `bin/command.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
         },
         "sort-packages": true
     },
+    "autoload": {
+        "files": [
+            "bin/command.php"
+        ]
+    },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^4.2"
     },


### PR DESCRIPTION
There is no autoload key in Composer.

This adds the files autoloader, as I think is the convention for files that contain `WP_CLI::add_command()` for a package.

```
    "autoload": {
        "files": [
            "bin/command.php"
        ]
    },
```