### PR TITLE
Fix: Undefined array key warning / Require wp-cli 2.11 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "sort-packages": true
     },
     "require-dev": {
+        "wp-cli/wp-cli": "^2.11",
         "wp-cli/wp-cli-tests": "^4.2"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
```bash
PHP Warning:  Undefined array key "hook" in /.../wp-cli/handbook/bin/command.php on line 438
```

The `$cmd['hook']` value

https://github.com/wp-cli/handbook/blob/bebc75bc7fa0a1c65ee07bb8904ad9f7a6930bb1/bin/command.php#L426

which stems from 

https://github.com/wp-cli/handbook/blob/bebc75bc7fa0a1c65ee07bb8904ad9f7a6930bb1/bin/command.php#L168

which uses `CLI_Command::command_to_array()`

was added in the (yet to be released) [v2.11](https://github.com/wp-cli/wp-cli/blob/0ca6d920123ac904c918d69181edc5071dc92c9d/php/commands/src/CLI_Command.php#L37-L54) (vs [v2.10](https://github.com/wp-cli/wp-cli/blob/v2.10.0/php/commands/src/CLI_Command.php#L37-L53))  – [wp-cli/wp-cli@`6d78633`](https://github.com/wp-cli/wp-cli/commit/6d78633580dbec4856979210b597a1c9c687e163#diff-18528f4b84d33052a713ae946299186f866df341008209e31bdd56be17e4c557).

This PR adds `"wp-cli/wp-cli": "^2.11"` to `composer.json` so the correct minimum version is used.