### PR TITLE
Fix Parsing of Multiline Argument Descriptions

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -630,7 +630,9 @@ EOT;
 					$key = key( $ret['parameters'][ $param_name ] );
 					reset( $ret['parameters'][ $param_name ] );
 					if ( ! empty( $ret['parameters'][ $param_name ][ $key ][2] )
-						&& '{' === substr( $ret['parameters'][ $param_name ][ $key ][2], -1 ) ) {
+						&&
+						in_array( substr( $ret['parameters'][ $param_name ][ $key ][2], -1 ), [ '{', ',' ], true )
+					) {
 						$in_param = [ $param_name, $key ];
 					}
 				}


### PR DESCRIPTION
Fixes: #477 

This pull request addresses a parsing error in the WP CLI handbook where multiline argument descriptions in the `Utils\http_request()` method were not being handled correctly. Previously, the parser failed to recognize `,` as a valid character that could indicate the continuation of an argument description onto a new line.

Changes Made:

Updated the conditional check in the parsing logic. Now, the parser recognizes both `{` and `,` characters as potential indicators of a multiline argument. This ensures that argument descriptions that continue after these characters are correctly parsed and included in the documentation.