### PR TITLE
Contributor day changes for WCUS 2024

### DIFF
--- a/contributor-day.md
+++ b/contributor-day.md
@@ -6,7 +6,7 @@ We'd love to help you submit at least one pull request, so we put together this 
 
 When you submit your pull request, add `Related https://github.com/wp-cli/wp-cli/issues/5985` so we can see all pull requests created during the day. We'll give these some special promotion in the next release notes.
 
-Your table leads for the day are: [schlessera](https://github.com/schlessera), [danielbachhuber](https://github.com/danielbachhuber)
+Your table leads for the day are: [schlessera](https://github.com/schlessera), [BrianHenryIE](https://github.com/BrianHenryIE)
 
 A few seasoned WP-CLI contributors are also helping out: TBD
 

--- a/contributor-day.md
+++ b/contributor-day.md
@@ -32,7 +32,6 @@ To help you be successful during Contributor Day, we curated a list of reasonabl
 
 **New contributors**
 
-- [Clarify docs arugment](https://github.com/wp-cli/language-command/issues/90)
 - ["wp config create" generates wrong DB_PASSWORD in wp-config.php when db password has "](https://github.com/wp-cli/config-command/issues/180)
 - [Import into specific directory/location](https://github.com/wp-cli/media-command/issues/146)
 - [Add --exclude=<file>,<file> argument to skip files](https://github.com/wp-cli/checksum-command/issues/64)

--- a/contributor-day.md
+++ b/contributor-day.md
@@ -4,7 +4,7 @@ Welcome to WordCamp Contributor Day! We appreciate you sharing your time with WP
 
 We'd love to help you submit at least one pull request, so we put together this guide to make it as straightforward as possible. We're here to support you however we can.
 
-When you submit your pull request, add `Related https://github.com/wp-cli/wp-cli/issues/5955` so we can see all pull requests created during the day. We'll give these some special promotion in the next release notes.
+When you submit your pull request, add `Related https://github.com/wp-cli/wp-cli/issues/5985` so we can see all pull requests created during the day. We'll give these some special promotion in the next release notes.
 
 Your table leads for the day are: [schlessera](https://github.com/schlessera), [danielbachhuber](https://github.com/danielbachhuber)
 


### PR DESCRIPTION
https://make.wordpress.org/cli/handbook/contributions/contributor-day/

Update the Contributor Day page for WordCamp US 2024

* Table lead names
* GitHub issue for tracking day's contributions
* Remove already closed issue