### PR TITLE
Fix typo in troubleshooting.md

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -33,7 +33,7 @@ If you want to run WP-CLI remotely using SSH, it is required that the command `w
 * `WP_CLI_CONFIG_PATH` – Path to the global config.yml file. Default is `~/.wp-cli/config.yml`.
 * `WP_CLI_DISABLE_AUTO_CHECK_UPDATE` – Disable WP-CLI automatic checks for updates.
 * `WP_CLI_PACKAGES_DIR` – Directory to store packages installed through WP-CLI’s package management. Default is `* ~/.wp-cli/packages/`.
-* `WP_CLI_PHP – PHP` binary path to use when overriding the system default (only works for non-Phar installation).
+* `WP_CLI_PHP` – PHP binary path to use when overriding the system default (only works for non-Phar installation).
 * `WP_CLI_PHP_ARGS` – Arguments to pass to the PHP binary when invoking WP-CLI (only works for non-Phar installation).
 * `WP_CLI_SSH_PRE_CMD` – When using `--ssh=<ssh>`, perform a command before WP-CLI calls WP-CLI on the remote server.
 * `WP_CLI_STRICT_ARGS_MODE` – Avoid ambiguity by telling WP-CLI to treat any arguments before the command as global, and after the command as local.


### PR DESCRIPTION
code block for `WP_CLI_PHP` var wrongly included part of the description