### PR TITLE
Update handbook after v2.12.0 release

### DIFF
--- a/bin/command.php
+++ b/bin/command.php
@@ -408,6 +408,7 @@ EOT;
 				'parent'          => null,
 			];
 		}
+
 		// Internal API pages.
 		foreach ( glob( WP_CLI_HANDBOOK_PATH . '/internal-api/*.md' ) as $file ) {
 			$slug     = basename( $file, '.md' );
@@ -426,6 +427,26 @@ EOT;
 				'parent'          => 'internal-api',
 			];
 		}
+
+		// Behat steps pages.
+		foreach ( glob( WP_CLI_HANDBOOK_PATH . '/behat-steps/*.md' ) as $file ) {
+			$slug     = basename( $file, '.md' );
+			$title    = '';
+			$contents = file_get_contents( $file );
+			if ( preg_match( '/^#\s(.+)/', $contents, $matches ) ) {
+				$title = $matches[1];
+			}
+			$manifest[ $slug ] = [
+				'title'           => $title,
+				'slug'            => $slug,
+				'markdown_source' => sprintf(
+					'https://github.com/wp-cli/handbook/blob/main/behat-steps/%s.md',
+					$slug
+				),
+				'parent'          => 'ibehat-stepsapi',
+			];
+		}
+
 		file_put_contents( WP_CLI_HANDBOOK_PATH . '/bin/handbook-manifest.json', json_encode( $manifest, JSON_PRETTY_PRINT ) );
 		WP_CLI::success( 'Generated bin/handbook-manifest.json' );
 	}

--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -1,9 +1,9 @@
 {
     "behat-steps": {
-      "title": "Behat Steps",
-      "slug": "behat-steps",
-      "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps.md",
-      "parent": null
+        "title": "Behat Steps",
+        "slug": "behat-steps",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps.md",
+        "parent": null
     },
     "bug-reports": {
         "title": "Bug Reports",
@@ -138,7 +138,7 @@
         "parent": null
     },
     "how-to-create-custom-plugins": {
-        "title": "",
+        "title": "How to create a custom plugin:",
         "slug": "how-to-create-custom-plugins",
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/how-to-create-custom-plugins.md",
         "parent": null
@@ -514,5 +514,287 @@
         "slug": "wp-cli-warning",
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/internal-api\/wp-cli-warning.md",
         "parent": "internal-api"
+    },
+    "given-a-custom-wp-content-directory": {
+        "title": "Given a custom wp-content directory",
+        "slug": "given-a-custom-wp-content-directory",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-custom-wp-content-directory.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-database": {
+        "title": "Given a database",
+        "slug": "given-a-database",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-database.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-dependency-on-current-wp-cli": {
+        "title": "Given a dependency on current wp-cli",
+        "slug": "given-a-dependency-on-current-wp-cli",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-dependency-on-current-wp-cli.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-downloaded-phar-with-the-same-version-version": {
+        "title": "Given \/^a downloaded Phar with (?:the same version|version &quot;([^&quot;]+)&quot;)$\/",
+        "slug": "given-a-downloaded-phar-with-the-same-version-version",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-downloaded-phar-with-the-same-version-version.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-misconfigured-wp-content-dir-constant-directory": {
+        "title": "Given a misconfigured WP_CONTENT_DIR constant directory",
+        "slug": "given-a-misconfigured-wp-content-dir-constant-directory",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-misconfigured-wp-content-dir-constant-directory.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-new-phar-with-the-same-version-version": {
+        "title": "Given \/^a new Phar with (?:the same version|version &quot;([^&quot;]+)&quot;)$\/",
+        "slug": "given-a-new-phar-with-the-same-version-version",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-new-phar-with-the-same-version-version.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-php-built-in-web-server-to-serve-subdir": {
+        "title": "Given a PHP built-in web server to serve :subdir",
+        "slug": "given-a-php-built-in-web-server-to-serve-subdir",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-php-built-in-web-server-to-serve-subdir.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-php-built-in-web-server": {
+        "title": "Given a PHP built-in web server",
+        "slug": "given-a-php-built-in-web-server",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-php-built-in-web-server.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-wp-installation-in-subdir": {
+        "title": "Given a WP install(ation) in :subdir",
+        "slug": "given-a-wp-installation-in-subdir",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-wp-installation-in-subdir.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-wp-installation-with-composer-and-a-custom-vendor-directory-vendor-directory": {
+        "title": "Given a WP install(ation) with Composer and a custom vendor directory :vendor_directory",
+        "slug": "given-a-wp-installation-with-composer-and-a-custom-vendor-directory-vendor-directory",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-wp-installation-with-composer-and-a-custom-vendor-directory-vendor-directory.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-wp-installation-with-composer": {
+        "title": "Given a WP install(ation) with Composer",
+        "slug": "given-a-wp-installation-with-composer",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-wp-installation-with-composer.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-wp-installation": {
+        "title": "Given a WP install(ation)",
+        "slug": "given-a-wp-installation",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-wp-installation.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-a-wp-multisite-subdirectory-subdomaininstall-installation": {
+        "title": "Given \/^a WP multisite (subdirectory|subdomain)?\\s?(install|installation)$\/",
+        "slug": "given-a-wp-multisite-subdirectory-subdomaininstall-installation",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-a-wp-multisite-subdirectory-subdomaininstall-installation.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-an-empty-cache": {
+        "title": "Given an empty cache",
+        "slug": "given-an-empty-cache",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-an-empty-cache.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-an-empty-directory": {
+        "title": "Given an empty directory",
+        "slug": "given-an-empty-directory",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-an-empty-directory.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-an-empty-non-existent-directory": {
+        "title": "Given \/^an? (empty|non-existent) ([^\\s]+) directory$\/",
+        "slug": "given-an-empty-non-existent-directory",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-an-empty-non-existent-directory.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-an-file-cache-file": {
+        "title": "Given \/^an? ([^\\s]+) (file|cache file):$\/",
+        "slug": "given-an-file-cache-file",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-an-file-cache-file.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-download": {
+        "title": "Given download:",
+        "slug": "given-download",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-download.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-replaced-with-in-the-file": {
+        "title": "Given \/^&quot;([^&quot;]+)&quot; replaced with &quot;([^&quot;]+)&quot; in the ([^\\s]+) file$\/",
+        "slug": "given-replaced-with-in-the-file",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-replaced-with-in-the-file.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-save-stdout-stderr-as": {
+        "title": "Given \/^save (STDOUT|STDERR) ([\\'].+[^\\'])?\\s?as \\{(\\w+)\\}$\/",
+        "slug": "given-save-stdout-stderr-as",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-save-stdout-stderr-as.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-save-the-file-as": {
+        "title": "Given \/^save the (.+) file ([\\'].+[^\\'])?as \\{(\\w+)\\}$\/",
+        "slug": "given-save-the-file-as",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-save-the-file-as.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-that-http-requests-to-will-respond-with": {
+        "title": "Given \/^that HTTP requests to (.*?) will respond with:$\/",
+        "slug": "given-that-http-requests-to-will-respond-with",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-that-http-requests-to-will-respond-with.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-these-installed-and-active-plugins": {
+        "title": "Given these installed and active plugins:",
+        "slug": "given-these-installed-and-active-plugins",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-these-installed-and-active-plugins.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-wp-config-php": {
+        "title": "Given wp-config.php",
+        "slug": "given-wp-config-php",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-wp-config-php.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "given-wp-files": {
+        "title": "Given WP files",
+        "slug": "given-wp-files",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/given-wp-files.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-an-email-should-be-sent-not-be-sent": {
+        "title": "Then \/^an email should (be sent|not be sent)$\/",
+        "slug": "then-an-email-should-be-sent-not-be-sent",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-an-email-should-be-sent-not-be-sent.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-should-be-a-json-array-containing": {
+        "title": "Then \/^STDOUT should be a JSON array containing:$\/",
+        "slug": "then-stdout-should-be-a-json-array-containing",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-should-be-a-json-array-containing.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-should-be-a-table-containing-rows": {
+        "title": "Then \/^STDOUT should be a table containing rows:$\/",
+        "slug": "then-stdout-should-be-a-table-containing-rows",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-should-be-a-table-containing-rows.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-should-be-csv-containing": {
+        "title": "Then \/^STDOUT should be CSV containing:$\/",
+        "slug": "then-stdout-should-be-csv-containing",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-should-be-csv-containing.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-should-be-json-containing": {
+        "title": "Then \/^STDOUT should be JSON containing:$\/",
+        "slug": "then-stdout-should-be-json-containing",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-should-be-json-containing.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-should-be-yaml-containing": {
+        "title": "Then \/^STDOUT should be YAML containing:$\/",
+        "slug": "then-stdout-should-be-yaml-containing",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-should-be-yaml-containing.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-should-end-with-a-table-containing-rows": {
+        "title": "Then \/^STDOUT should end with a table containing rows:$\/",
+        "slug": "then-stdout-should-end-with-a-table-containing-rows",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-should-end-with-a-table-containing-rows.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-be-a-number": {
+        "title": "Then \/^(STDOUT|STDERR) should be a number$\/",
+        "slug": "then-stdout-stderr-should-be-a-number",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-be-a-number.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-be-a-version-string-w": {
+        "title": "Then \/^(STDOUT|STDERR) should be a version string (&lt;|&lt;=|&gt;|&gt;=|==|=|!=|&lt;&gt;) ([+\\w.{}-]+)$\/",
+        "slug": "then-stdout-stderr-should-be-a-version-string-w",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-be-a-version-string-w.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-be-empty": {
+        "title": "Then \/^(STDOUT|STDERR) should be empty$\/",
+        "slug": "then-stdout-stderr-should-be-empty",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-be-empty.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-not-be-a-number": {
+        "title": "Then \/^(STDOUT|STDERR) should not be a number$\/",
+        "slug": "then-stdout-stderr-should-not-be-a-number",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-not-be-a-number.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-not-be-empty": {
+        "title": "Then \/^(STDOUT|STDERR) should not be empty$\/",
+        "slug": "then-stdout-stderr-should-not-be-empty",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-not-be-empty.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-not-match": {
+        "title": "Then \/^(STDOUT|STDERR) should( not)? match (((\\\/.+\\\/)|(#.+#))([a-z]+)?)$\/",
+        "slug": "then-stdout-stderr-should-not-match",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-not-match.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-stdout-stderr-should-strictly-be-contain-not-contain": {
+        "title": "Then \/^(STDOUT|STDERR) should( strictly)? (be|contain|not contain):$\/",
+        "slug": "then-stdout-stderr-should-strictly-be-contain-not-contain",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-stdout-stderr-should-strictly-be-contain-not-contain.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-the-contents-of-the-file-should-not-match": {
+        "title": "Then \/^the contents of the (.+) file should( not)? match (((\\\/.+\\\/)|(#.+#))([a-z]+)?)$\/",
+        "slug": "then-the-contents-of-the-file-should-not-match",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-the-contents-of-the-file-should-not-match.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-the-file-directory-should-strictly-exist-not-exist-be-contain-not-contain": {
+        "title": "Then \/^the (.+) (file|directory) should( strictly)? (exist|not exist|be:|contain:|not contain:)$\/",
+        "slug": "then-the-file-directory-should-strictly-exist-not-exist-be-contain-not-contain",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-the-file-directory-should-strictly-exist-not-exist-be-contain-not-contain.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-the-http-status-code-should-be-code": {
+        "title": "Then the HTTP status code should be :code",
+        "slug": "then-the-http-status-code-should-be-code",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-the-http-status-code-should-be-code.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "then-the-return-code-should-not-be": {
+        "title": "Then \/^the return code should( not)? be (\\d+)$\/",
+        "slug": "then-the-return-code-should-not-be",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/then-the-return-code-should-not-be.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "when-i-launch-in-the-background": {
+        "title": "When \/^I launch in the background `([^`]+)`$\/",
+        "slug": "when-i-launch-in-the-background",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/when-i-launch-in-the-background.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "when-i-run-try-from": {
+        "title": "When \/^I (run|try) `([^`]+)` from '([^\\s]+)'$\/",
+        "slug": "when-i-run-try-from",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/when-i-run-try-from.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "when-i-run-try-the-previous-command-again": {
+        "title": "When \/^I (run|try) the previous command again$\/",
+        "slug": "when-i-run-try-the-previous-command-again",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/when-i-run-try-the-previous-command-again.md",
+        "parent": "ibehat-stepsapi"
+    },
+    "when-i-run-try": {
+        "title": "When \/^I (run|try) `([^`]+)`$\/",
+        "slug": "when-i-run-try",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/behat-steps\/when-i-run-try.md",
+        "parent": "ibehat-stepsapi"
     }
 }

--- a/internal-api/wp-cli-add-hook.md
+++ b/internal-api/wp-cli-add-hook.md
@@ -11,7 +11,7 @@ Schedule a callback to be executed at a certain point.
 <div>
 <strong>$when</strong> (string) Identifier for the hook.<br />
 <strong>$callback</strong> (mixed) Callback to execute when hook is called.<br />
-<strong>@return</strong> (null) <br />
+<strong>@return</strong> (void) <br />
 </div>
 
 

--- a/internal-api/wp-cli-debug.md
+++ b/internal-api/wp-cli-debug.md
@@ -11,7 +11,7 @@ Display debug message prefixed with &quot;Debug: &quot; when `--debug` is used.
 <div>
 <strong>$message</strong> (string|WP_Error|Exception|Throwable) Message to write to STDERR.<br />
 <strong>$group</strong> (string|bool) Organize debug message to a specific group.<br />
-<strong>@return</strong> (null) <br />
+<strong>@return</strong> (void) <br />
 </div>
 
 

--- a/internal-api/wp-cli-line.md
+++ b/internal-api/wp-cli-line.md
@@ -10,7 +10,7 @@ Display informational message without prefix, and ignore `--quiet`.
 
 <div>
 <strong>$message</strong> (string) Message to display to the end user.<br />
-<strong>@return</strong> (null) <br />
+<strong>@return</strong> (void) <br />
 </div>
 
 

--- a/internal-api/wp-cli-runcommand.md
+++ b/internal-api/wp-cli-runcommand.md
@@ -10,7 +10,7 @@ Run a WP-CLI command.
 
 <div>
 <strong>$command</strong> (string) WP-CLI command to run, including arguments.<br />
-<strong>$options</strong> (array) Configuration options for command execution.<br />
+<strong>$options</strong> (array) {<br />    Configuration options for command execution.<br />    @type bool        $launch     Launches a new process (true) or reuses the existing process (false). Default: true.<br />    @type bool        $exit_error Halts the script on error. Default: true.<br />    @type bool|string $return     Returns output as an object when set to 'all' (string), return just the 'stdout', 'stderr', or 'return_code' (string) of command, or print directly to stdout/stderr (false). Default: false.<br />    @type bool|string $parse      Parse returned output as 'json' (string); otherwise, output is unchanged (false). Default: false.<br />@param array $command_args Contains additional command line arguments for the command. Each element represents a single argument. Default: empty array.<br />}<br />
 <strong>@return</strong> (mixed) <br />
 </div>
 

--- a/internal-api/wp-cli-success.md
+++ b/internal-api/wp-cli-success.md
@@ -10,7 +10,7 @@ Display success message prefixed with &quot;Success: &quot;.
 
 <div>
 <strong>$message</strong> (string) Message to write to STDOUT.<br />
-<strong>@return</strong> (null) <br />
+<strong>@return</strong> (void) <br />
 </div>
 
 
@@ -18,7 +18,7 @@ Display success message prefixed with &quot;Success: &quot;.
 
 ## Notes
 
-Success message is written to STDOUT.
+Success message is written to STDOUT, or discarded when `--quiet` flag is supplied.
 
 Typically recommended to inform user of successful script conclusion.
 

--- a/internal-api/wp-cli-utils-format-items.md
+++ b/internal-api/wp-cli-utils-format-items.md
@@ -10,8 +10,8 @@ Render a collection of items as an ASCII table, JSON, CSV, YAML, list of ids, or
 
 <div>
 <strong>$format</strong> (string) Format to use: 'table', 'json', 'csv', 'yaml', 'ids', 'count'.<br />
-<strong>$items</strong> (array) An array of items to output.<br />
-<strong>$fields</strong> (array|string) Named fields for each item of data. Can be array or comma-separated list.<br />
+<strong>$items</strong> (array&lt;mixed&gt;) An array of items to output.<br />
+<strong>$fields</strong> (array&lt;string&gt;|string) Named fields for each item of data. Can be array or comma-separated list.<br />
 </div>
 
 

--- a/internal-api/wp-cli-utils-get-flag-value.md
+++ b/internal-api/wp-cli-utils-get-flag-value.md
@@ -9,7 +9,7 @@ Return the flag value or, if it's not set, the $default value.
     WP_CLI\Utils\get_flag_value( $assoc_args, $flag, $default = null )
 
 <div>
-<strong>$assoc_args</strong> (array) Arguments array.<br />
+<strong>$assoc_args</strong> (array&lt;string,string|bool&gt;) Arguments array.<br />
 <strong>$flag</strong> (string) Flag to get the value.<br />
 <strong>$default</strong> (mixed) Default value for the flag. Default: NULL.<br />
 <strong>@return</strong> (mixed) <br />

--- a/internal-api/wp-cli-utils-parse-ssh-url.md
+++ b/internal-api/wp-cli-utils-parse-ssh-url.md
@@ -9,6 +9,8 @@ Parse a SSH url for its host, port, and path.
     WP_CLI\Utils\parse_ssh_url( $url, $component = -1 )
 
 <div>
+<strong>$url</strong> (string) <br />
+<strong>$component</strong> (int) <br />
 <strong>@return</strong> (mixed) <br />
 </div>
 

--- a/internal-api/wp-cli-utils-parse-str-to-argv.md
+++ b/internal-api/wp-cli-utils-parse-str-to-argv.md
@@ -10,7 +10,7 @@ Parse a string of command line arguments into an $argv-esqe variable.
 
 <div>
 <strong>$arguments</strong> (string) <br />
-<strong>@return</strong> (array) <br />
+<strong>@return</strong> (array&lt;string&gt;) <br />
 </div>
 
 

--- a/internal-api/wp-cli-utils-proc-open-compat.md
+++ b/internal-api/wp-cli-utils-proc-open-compat.md
@@ -10,11 +10,11 @@ Windows compatible `proc_open()`. Works around bug in PHP, and also deals with *
 
 <div>
 <strong>$cmd</strong> (string) Command to execute.<br />
-<strong>$descriptorspec</strong> (array) Indexed array of descriptor numbers and their values.<br />
-<strong>&amp;$pipes</strong> (array) Indexed array of file pointers that correspond to PHP's end of any pipes that are created.<br />
+<strong>string&gt;</strong> (array&lt;int,) $descriptorspec Indexed array of descriptor numbers and their values.<br />
+<strong>string&gt;</strong> (array&lt;int,) &$pipes         Indexed array of file pointers that correspond to PHP's end of any pipes that are created.<br />
 <strong>$cwd</strong> (string) Initial working directory for the command.<br />
-<strong>$env</strong> (array) Array of environment variables.<br />
-<strong>$other_options</strong> (array) Array of additional options (Windows only).<br />
+<strong>string&gt;</strong> (array&lt;string,) $env            Array of environment variables.<br />
+<strong>$other_options</strong> (array&lt;string&gt;) Array of additional options (Windows only).<br />
 <strong>@return</strong> (resource) stripped of any environment variable settings.<br />
 </div>
 

--- a/internal-api/wp-cli-utils-report-batch-operation-results.md
+++ b/internal-api/wp-cli-utils-report-batch-operation-results.md
@@ -15,6 +15,7 @@ Report the results of the same operation against multiple resources.
 <strong>$successes</strong> (integer) Number of successful operations.<br />
 <strong>$failures</strong> (integer) Number of failures.<br />
 <strong>$skips</strong> (null|integer) Optional. Number of skipped operations. Default null (don't show skips).<br />
+<strong>@return</strong> (void) <br />
 </div>
 
 

--- a/internal-api/wp-cli-utils-write-csv.md
+++ b/internal-api/wp-cli-utils-write-csv.md
@@ -10,8 +10,8 @@ Write data as CSV to a given file.
 
 <div>
 <strong>$fd</strong> (resource) File descriptor.<br />
-<strong>$rows</strong> (array) Array of rows to output.<br />
-<strong>$headers</strong> (array) List of CSV columns (optional).<br />
+<strong>$rows</strong> (array&lt;string&gt;) Array of rows to output.<br />
+<strong>$headers</strong> (array&lt;string&gt;) List of CSV columns (optional).<br />
 </div>
 
 

--- a/internal-api/wp-cli-warning.md
+++ b/internal-api/wp-cli-warning.md
@@ -10,7 +10,7 @@ Display warning message prefixed with &quot;Warning: &quot;.
 
 <div>
 <strong>$message</strong> (string|WP_Error|Exception|Throwable) Message to write to STDERR.<br />
-<strong>@return</strong> (null) <br />
+<strong>@return</strong> (void) <br />
 </div>
 
 
@@ -18,7 +18,7 @@ Display warning message prefixed with &quot;Warning: &quot;.
 
 ## Notes
 
-Warning message is written to STDERR.
+Warning message is written to STDERR, or discarded when `--quiet` flag is supplied.
 
 Use instead of `WP_CLI::debug()` when script execution should be permitted
 to continue.


### PR DESCRIPTION
In #560 I forgot to update the manifest, so the generated pages weren't actually imported into WordPress yet.

Plus, there were some other docs updates in the meantime.