### PR TITLE
Update hosting-companies.md

### DIFF
--- a/hosting-companies.md
+++ b/hosting-companies.md
@@ -73,6 +73,7 @@ In alphabetical order:
 * [ScanNet](https://www.scannet.dk)
 * [Seravo.com](https://seravo.com)
 * [Servebolt.com](https://servebolt.com)
+* [Simplenet.ro](https://simplenet.ro)
 * [Simply.com](https://www.simply.com)
 * [Site5](https://www.site5.com/)
 * [SiteDistrict](https://sitedistrict.com/)


### PR DESCRIPTION
Added simplenet.ro. While Simplenet has been rebranded to Kiravo in the international market, it still operates as Simplenet in the Romanian market on the .ro domain as a separate brand from Kiravo.