### PR TITLE
Docs: Fix links in installing.md & quick-start.md

### DIFF
--- a/guides/installing.md
+++ b/guides/installing.md
@@ -69,7 +69,7 @@ WP-CLI is at the latest version.
 
 Want to live life on the edge? Run `wp cli update --nightly` to use the latest nightly build of WP-CLI. The nightly build is more or less stable enough for you to use in your local environment, and always includes the latest and greatest.
 
-For more information about `wp cli update`, including flags and options that can be used, read the full [docs page on the update command](https://wp-cli.org/commands/cli/update/).
+For more information about `wp cli update`, including flags and options that can be used, read the full [docs page on the update command](https://developer.wordpress.org/cli/commands/cli/update/).
 
 ### Tab completions
 

--- a/guides/quick-start.md
+++ b/guides/quick-start.md
@@ -141,4 +141,4 @@ When ready to replace the links, run:
 wp search-replace 'http://oldsite.com' 'http://newsite.com'
 ```
 
-Wondering what's next? Browse through [all of WP-CLI's commands](https://developer.wordpress.org/cli/commands/) to explore your new world. For more detailed information about creating custom commands, visit the [WP-CLI Commands Cookbook](https://make.wordpress.org/cli/handbook/guides/commands-cookbook/). Or, catch up with [shell friends](https://make.wordpress.org/cli/handbook/shell-friends/) to learn about helpful command line utilities.
+Wondering what's next? Browse through [all of WP-CLI's commands](https://developer.wordpress.org/cli/commands/) to explore your new world. For more detailed information about creating custom commands, visit the [WP-CLI Commands Cookbook](https://make.wordpress.org/cli/handbook/guides/commands-cookbook/). Or, catch up with [shell friends](https://make.wordpress.org/cli/handbook/references/shell-friends/) to learn about helpful command line utilities.


### PR DESCRIPTION
Hi! This PR updates two handbook links so they go straight to the right pages (no redirects). Using the direct, official links keeps the docs clear and reliable.

Changes

installing.md (line 72)

From: https://wp-cli.org/commands/cli/update/

To: https://developer.wordpress.org/cli/commands/cli/update/

quick-start.md (line 144)

From: https://make.wordpress.org/cli/handbook/shell-friends/

To: https://make.wordpress.org/cli/handbook/references/shell-friends/

Why

Use the official command docs on developer.wordpress.org.

Fix the handbook path to the references section.

Avoid extra redirects and keep the docs tidy.

Impact

Docs-only change; no code behavior affected.

I manually checked that both updated links open the expected pages.