### PR TITLE
Fix typo in wp transient delete documentation

### DIFF
--- a/commands/transient/delete.md
+++ b/commands/transient/delete.md
@@ -12,7 +12,7 @@ See the [argument syntax](https://make.wordpress.org/cli/handbook/references/arg
 : Key for the transient.
 
 [\--network]
-: Delete the value of a network|site transient. On single site, this is is a specially-named cache key. On multisite, this is a global cache (instead of local to the site).
+: Delete the value of a network|site transient. On single site, this is a specially-named cache key. On multisite, this is a global cache (instead of local to the site).
 
 [\--all]
 : Delete all transients.


### PR DESCRIPTION
original statement : On single site, this is is a specially-named cache key.

fixed statement : On single site, this is a specially-named cache key.

This PR fixes a small typo in the wp transient delete command documentation.
No functional changes included.
