### PR TITLE
Update stale CI references in contributor docs

### DIFF
--- a/contributions/code-review.md
+++ b/contributions/code-review.md
@@ -10,7 +10,7 @@ Code review is a core part of the WP-CLI project's software development workflow
 
 We're currently using GitHub for everything. Read up on [our GitHub workflow](https://make.wordpress.org/cli/handbook/pull-requests/) for details of process, naming, usage of issues and pull requests. A moderately complex issue will typically be addressed across multiple pull requests, each tackling a distinct part of the issue. This makes review simpler because each review stage will be looking at a small code.
 
-- On every commit pushed to a GH branch, our CI automated tests -- linting for all code, unit tests for functional code, and ideally, behavioral and automated acceptance testing -- are run on Travis.
+- On every commit pushed to a GitHub branch, our CI automated tests -- linting for all code, unit tests for functional code, and ideally, behavioral and automated acceptance testing -- are run through GitHub Actions.
 - If the build passes, the PR can be reviewed. If not, the original developer is responsible for getting the build to the point where it passes.
 - When the original developer is satisfied with their work, they can request a review from the [committers team](https://make.wordpress.org/cli/handbook/committers-credo/) by assigning `@wp-cli/committers` for review.
 - Simple pull requests can often be merged by the developer who reviews them. More complex changesets will often require conversations back and forth between reviewer and developer, and should have secondary reviewers.

--- a/contributions/governance.md
+++ b/contributions/governance.md
@@ -45,7 +45,7 @@ The [WP-CLI GitHub organization](https://github.com/wp-cli) contains all project
 
 [wp-cli/wp-cli](https://github.com/wp-cli/wp-cli) is the main project repository, which pulls in command packages and other dependencies through Composer. Composer defines which version of which dependencies is included in the build. Changes to command packages are included in WP-CLI proper when a stable release is tagged for the package.
 
-Nightly Phar builds are created by a Travis job that calls [deploy.sh](https://github.com/wp-cli/wp-cli/blob/master/ci/deploy.sh) and pushes the build artifact to the [builds repository](http://github.com/wp-cli/builds). Releases are prepared manually [in accordance to the release checklist](https://make.wordpress.org/cli/handbook/release-checklist/).
+Build artifacts are published to the [builds repository](https://github.com/wp-cli/builds). Releases are prepared manually [in accordance with the release checklist](https://make.wordpress.org/cli/handbook/release-checklist/).
 
 The `wp-cli.org` domain is currently owned by [andreascreten](https://github.com/andreascreten). DNS is managed through a [Cloudflare](https://www.cloudflare.com/) account that [danielbachhuber](https://github.com/danielbachhuber) holds credentials to.
 


### PR DESCRIPTION
## Summary

Updates stale contributor documentation that still referred to Travis CI.

## Changes

- Replace Travis CI wording with GitHub Actions wording in the code review docs.
- Remove a dead reference to `ci/deploy.sh`, which no longer exists in `wp-cli/wp-cli`.
- Update the builds repository link to HTTPS.


## Verification

- Confirmed `wp-cli/wp-cli` no longer has `.travis.yml`.
- Confirmed `wp-cli/wp-cli` no longer has `ci/deploy.sh`.
- Confirmed active GitHub Actions workflows exist in `.github/workflows/`.
- Ran `git diff --check`.