### PR TITLE
Update custom plugin guide CI references

### DIFF
--- a/how-to/how-to-create-custom-plugins.md
+++ b/how-to/how-to-create-custom-plugins.md
@@ -11,24 +11,18 @@ The following command uses several options to lets us specify the plugin slug, i
     Success: Created test files.
 ```
 
-The above command generates a new folder called `wpcli-demo-plugin` in the plugins directory, with the following files structure.
+The above command generates a new folder called `wpcli-demo-plugin` in the plugins directory, with files such as:
 
-    | - bin/
-    | - tests/
-    | - .gitignore
-    | - .editorconfig
-    | - .phpcs.xml.dist
-    | - .circleci/config.yml
-    | - Gruntfile.js
-    | - package.json
-    | - phpunit.xml.dist
-    | - readme.txt
-    | - wpcli-demo-plugin.php
+- `wpcli-demo-plugin.php`
+- `readme.txt`
+- `package.json`
+- `.gitignore`
+- `.editorconfig`
 
-Unless you use the --skip-tests flag the following files are always generated:
+Unless you use the --skip-tests flag, test-related files are generated too. These include:
 
 - `phpunit.xml.dist` is the configuration file for PHPUnit.
-- `.circleci/config.yml` is the configuration file for CircleCI. Use `--ci=<provider>` to select a different service.
+- A CI configuration file. Use `--ci=<provider>` to select a supported CI provider.
 - `bin/install-wp-tests.sh` configures the WordPress test suite and a test database.
 - `tests/bootstrap.php` is the file that makes the current plugin active when running the test suite.
 - `tests/test-sample.php` is a sample file containing test cases.

--- a/how-to/how-to-create-custom-plugins.md
+++ b/how-to/how-to-create-custom-plugins.md
@@ -18,7 +18,7 @@ The above command generates a new folder called `wpcli-demo-plugin` in the plugi
     | - .gitignore
     | - .editorconfig
     | - .phpcs.xml.dist
-    | - .travis.yml
+    | - .circleci/config.yml
     | - Gruntfile.js
     | - package.json
     | - phpunit.xml.dist
@@ -28,7 +28,7 @@ The above command generates a new folder called `wpcli-demo-plugin` in the plugi
 Unless you use the --skip-tests flag the following files are always generated:
 
 - `phpunit.xml.dist` is the configuration file for PHPUnit.
-- `.travis.yml` is the configuration file for Travis CI. Use `--ci=<provider>` to select a different service.
+- `.circleci/config.yml` is the configuration file for CircleCI. Use `--ci=<provider>` to select a different service.
 - `bin/install-wp-tests.sh` configures the WordPress test suite and a test database.
 - `tests/bootstrap.php` is the file that makes the current plugin active when running the test suite.
 - `tests/test-sample.php` is a sample file containing test cases.


### PR DESCRIPTION
## Summary

Updates the custom plugin guide so its generated file list matches the current `wp scaffold plugin` documentation.

## Changes

- Replace the stale `.travis.yml` reference with `.circleci/config.yml`.
- Update the CI description from Travis CI to CircleCI.
- Keep the existing `--ci=<provider>` guidance for alternate CI providers.

## Verification

- Confirmed `wp scaffold plugin` docs list `.circleci/config.yml` as the default generated CI configuration.
- Confirmed `wp-cli/scaffold-command` documents CircleCI as the default CI provider.
- Ran `git diff --check`.
- Ran `composer lint`.
- Ran `composer phpcs`.
- Ran `composer phpunit`.
- Ran `composer behat` (skipped: no `behat.yml`).

Note: `composer phpstan` currently fails on existing type errors in `bin/Handbook_Command.php` unrelated to this documentation-only change.