### PR TITLE
Correct render binding PHPDoc type

### DIFF
--- a/bin/Handbook_Command.php
+++ b/bin/Handbook_Command.php
@@ -137,7 +137,6 @@ EOT;
 				$api['related']     = array_values( $api['related'] );
 				$api['has_related'] = ! empty( $api['related'] );
 
-				// @phpstan-ignore argument.type
 				$api_doc = self::render( 'internal-api.mustache', $api );
 				$path    = self::get_handbook_path() . "/internal-api/{$api['api_slug']}.md";
 				if ( ! is_dir( dirname( $path ) ) ) {
@@ -215,7 +214,6 @@ EOT;
 				$api['related']     = array_values( $api['related'] );
 				$api['has_related'] = ! empty( $api['related'] );
 
-				// @phpstan-ignore argument.type
 				$api_doc = self::render( 'behat-steps.mustache', $api );
 				$path    = self::get_handbook_path() . "/behat-steps/{$api['api_slug']}.md";
 				if ( ! is_dir( dirname( $path ) ) ) {
@@ -872,7 +870,7 @@ EOT;
 
 	/**
 	 * @param string $path
-	 * @param array<string, array<int, array<string, array<string, mixed>|string>>> $binding
+	 * @param array<string, mixed> $binding
 	 */
 	private static function render( string $path, $binding ): string {
 		$m        = new Mustache_Engine();


### PR DESCRIPTION
## Summary

This updates the PHPDoc for `Handbook_Command::render()` so it matches the data that is actually passed to the method.

The method renders Mustache templates, and the binding data can contain strings, booleans, and nested arrays. The old PHPDoc was too narrow, which made PHPStan fail on valid call sites.

## Changes

- Change the `$binding` type to `array<string, mixed>`.
- Remove two PHPStan ignore comments that are no longer needed.

## Verification

- Ran `composer test`
- Ran `git diff --check`