### PR TITLE
Update plugin unit tests support link

### DIFF
--- a/how-to/plugin-unit-tests.md
+++ b/how-to/plugin-unit-tests.md
@@ -65,7 +65,7 @@ NOTE: This script can be run multiple times without errors, but it will *not* ov
 phpunit
 ```
 
-If you have trouble running the install script or PHPUnit, check [Support section](http://wp-cli.org/#support) for help and answers to common issues.
+If you have trouble running the install script or PHPUnit, check the [common issues guide](https://make.wordpress.org/cli/handbook/guides/common-issues/) for help and answers to common issues.
 
 ## Integrating WP Unit Testing in Windows
 


### PR DESCRIPTION
## Summary

Updates a stale support link in the plugin unit tests guide.

The old `wp-cli.org/#support` link now redirects to the general WordPress.org CLI page, so this points readers to the current common issues guide instead.

## Verification

- Ran `git diff --check`