### PR TITLE
Update package discovery guidance

### DIFF
--- a/guides/commands-cookbook.md
+++ b/guides/commands-cookbook.md
@@ -8,7 +8,7 @@ WP-CLI's goal is to offer a complete alternative to the WordPress admin; for any
 
 _But_, the WordPress admin is a Swiss Army knife of infinite complexity. There's no way just this project could handle every use case. This is why WP-CLI includes a set of [common internal commands](https://developer.wordpress.org/cli/commands/), while also offering a [rich internal API](https://make.wordpress.org/cli/handbook/internal-api/) for third-parties to write and register their own commands.
 
-WP-CLI commands can be [distributed as standalone packages](https://wp-cli.org/package-index/), or bundled with WordPress plugins or themes. For the former, you can use `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)) to dynamically generate everything but the command itself.
+WP-CLI commands can be distributed as standalone packages, or bundled with WordPress plugins or themes. Standalone packages can be published as Composer packages and discovered through [Packagist](https://packagist.org/?type=wp-cli-package). You can use `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)) to dynamically generate everything but the command itself.
 
 Packages are to WP-CLI as plugins are to WordPress. There are distinct differences in the approach you should take to creating a WP-CLI package.  While WP-CLI is an ever-growing alternative to /wp-admin it is important to note that you must first write your package to work with the WP-CLI internal API before considering how you work with WordPress APIs.
 
@@ -24,7 +24,7 @@ Third-party commands:
 
 * Can be defined in plugins or themes.
 * Can be easily scaffolded as standalone projects with `wp scaffold package` ([repo](https://github.com/wp-cli/scaffold-package-command)).
-* Can be distributed independent of a plugin or theme in the [Package Index](https://wp-cli.org/package-index/).
+* Can be distributed independent of a plugin or theme as Composer packages, Git repositories, local paths, or ZIP files.
 
 All commands:
 

--- a/guides/installing-packages.md
+++ b/guides/installing-packages.md
@@ -8,7 +8,7 @@ To find existing packages to install, take a look at [Packagist](https://packagi
 
 Use the `wp package install` command to install a package. Packages can be specified as:
 
-* Package name from WP-CLI's package index
+* Composer package name
 * Git URL accessible by the current shell user
 * Path to a directory on the local machine
 * Local or remote .zip file

--- a/guides/sharing-wp-cli-packages.md
+++ b/guides/sharing-wp-cli-packages.md
@@ -23,16 +23,7 @@ First, create your Composer project.
 
     $ mkdir /usr/local/lib/wp-cli-packages
     $ cd /usr/local/lib/wp-cli-packages
-    $ composer init -n --name=runcommand/wp-cli-packages -s=dev --repository=https://wp-cli.org/package-index/
-    $ composer require runcommand/hook
-    Using version dev-master for runcommand/hook
-    ./composer.json has been updated
-    Loading composer repositories with package information
-    Updating dependencies (including require-dev)
-      - Installing runcommand/hook (dev-master 7a7beae)
-        Cloning 7a7beae2013eeea243cc44524a7c5c21da11979e
-
-    Writing lock file
-    Generating autoload files
+    $ composer init -n --name=runcommand/wp-cli-packages -s=dev
+    $ composer require wp-cli/server-command
 
 Now, once your Composer project has a dependency or two, you can use `wp --require=<path/to/autoload>` (or the equivalent `config.yml` statement) to load the packages into WP-CLI.


### PR DESCRIPTION
## Summary

Updates handbook package docs that still pointed people toward the deprecated WP-CLI Package Index.

## Changes

- Refer to Packagist for discovering standalone WP-CLI packages.
- Replace “Package Index” wording with Composer package wording.
- Remove the old Package Index repository example from the shared Composer project setup.
- Use `wp-cli/server-command` as the example package instead of `runcommand/hook`.

## Verification

- Confirmed `wp-cli/server-command` is available on Packagist as a `wp-cli-package`.
- Confirmed the old Package Index guidance is only left in generated command docs, not the hand-written guide pages.
- Ran `git diff --check`.