### PR TITLE
Fix doctor YAML example

### DIFF
--- a/guides/doctor/doctor-check-plugin-status.md
+++ b/guides/doctor/doctor-check-plugin-status.md
@@ -1,8 +1,8 @@
 # Check status of a given plugin
 
-One of the check types included in `wp doctor` is `Plugin_Status`, or the ability to assert that a given plugin should be active, installed, or uninstalled. Although the check type isn't use by any of the [default diagnostic checks](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-default-checks/), you can use the `Plugin_Status` check type in your [custom `doctor.yml` configuration file](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-customize-config/).
+One of the check types included in `wp doctor` is `Plugin_Status`, or the ability to assert that a given plugin should be active, installed, or uninstalled. Although the check type isn't used by any of the [default diagnostic checks](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-default-checks/), you can use the `Plugin_Status` check type in your [custom `doctor.yml` configuration file](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-customize-config/).
 
-As an example, here are two checks using `Plugin_Status`, one which ensures Akismet is active on the system and other which ensures Hello Dolly is uninstalled:
+As an example, here are two checks using `Plugin_Status`, one which ensures Akismet is active on the system and another which ensures Hello Dolly is uninstalled:
 
     plugin-akismet-active:
       check: Plugin_Status

--- a/guides/doctor/doctor-customize-config.md
+++ b/guides/doctor/doctor-customize-config.md
@@ -1,6 +1,6 @@
 # Customize doctor diagnostic checks
 
-Even though `wp doctor` comes with a [number of default diagnostic checks](https://make.wordpress.org/cli/handbook/doctor-default-checks/), it's designed with extensibility at its core. Checks are defined at runtime, read from a `doctor.yml` configuration file naming each check with its options.
+Even though `wp doctor` comes with a [number of default diagnostic checks](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-default-checks/), it's designed with extensibility at its core. Checks are defined at runtime, read from a `doctor.yml` configuration file naming each check with its options.
 
 ## doctor.yml format
 
@@ -21,7 +21,7 @@ In this example:
 *   `Autoload_Options_Size` and `Constant_Definition` are reusable check classes in the `runcommand\Doctor\Checks` namespace. You can use them too, or you can write your own class extending `runcommand\Doctor\Checks\Check` and supply it as 'class: yourNamespace\\yourClassName'.
 *   'constant' and 'falsy' are configuration options accepted by the `Constant_Definition` class. In this case, we're telling doctor to ensure `SAVEQUERIES` is either false or undefined.
 
-For the sake of completeness, it's also worth noting `Autoload_Options_Size` accepts 'threshold\_kb' as an optional configuration option. The default value for 'threshold\_kb' is 900, so it doesn't needed be included in the `doctor.yml`.
+For the sake of completeness, it's also worth noting `Autoload_Options_Size` accepts 'threshold\_kb' as an optional configuration option. The default value for 'threshold\_kb' is 900, so it doesn't need to be included in the `doctor.yml`.
 
 ## Custom doctor.yml configuration files
 
@@ -40,7 +40,7 @@ Take a look at this example:
       options:
         constant: DISALLOW_FILE_MODS
         falsy: true
-    plugin-akismet-active
+    plugin-akismet-active:
       check: Plugin_Status
       options:
         plugin: akismet

--- a/guides/doctor/doctor-default-checks.md
+++ b/guides/doctor/doctor-default-checks.md
@@ -1,6 +1,6 @@
 # Default doctor diagnostic checks
 
-Although it's power comes from its [ability to be customized](https://make.wordpress.org/cli/handbook/doctor-customize-config/), `wp doctor` includes a number of default diagnostic checks considered to be recommendations for production websites.
+Although its power comes from its [ability to be customized](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-customize-config/), `wp doctor` includes a number of default diagnostic checks considered to be recommendations for production websites.
 
 Use `wp doctor list` to view these default checks:
 
@@ -134,4 +134,4 @@ To explain these further:
 *   Because `SAVEQUERIES` causes WordPress to save a backtrace for every SQL query, which is an expensive operation, using `SAVEQUERIES` in production is discouraged.
 *   WordPress minor versions are typically security releases that should be applied immediately.
 
-If you [create a custom `doctor.yml` config file](https://make.wordpress.org/cli/handbook/doctor-customize-config/), you can use `wp doctor list --config=<file>` to view the diagnostic checks listed in the file.
+If you [create a custom `doctor.yml` config file](https://make.wordpress.org/cli/handbook/guides/doctor/doctor-customize-config/), you can use `wp doctor list --config=<file>` to view the diagnostic checks listed in the file.


### PR DESCRIPTION
## Summary

Fixes an invalid `doctor.yml` example in the doctor customization guide.

## Changes

- Add the missing colon after `plugin-akismet-active`.
- Update redirected doctor guide links to their canonical URLs.
- Fix a couple of small grammar issues in nearby doctor docs.

## Verification

- Confirmed the updated YAML example parses successfully.
- Ran `git diff --check`.