### PR TITLE
Add WP-CLI support page

### DIFF
--- a/bin/handbook-manifest.json
+++ b/bin/handbook-manifest.json
@@ -479,6 +479,12 @@
         "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/references\/shell-friends.md",
         "parent": "references"
     },
+    "support": {
+        "title": "Support",
+        "slug": "support",
+        "markdown_source": "https:\/\/github.com\/wp-cli\/handbook\/blob\/main\/support.md",
+        "parent": null
+    },
     "then-an-email-should-be-sent-not-be-sent": {
         "title": "Then \/^an email should (be sent|not be sent)$\/",
         "slug": "then-an-email-should-be-sent-not-be-sent",

--- a/contributions/repository-management.md
+++ b/contributions/repository-management.md
@@ -64,7 +64,7 @@ The labels that defined what state a given issue/pull request is in are prefixed
 Used states:
 
 * `state:unconfirmed` - The bug/problem in the issue could not be replicated yet or might be related to the reporter's environment.
-* `state:unsupported` - The issue is outside of the scope of a bug report and cannot be supported on GitHub. The reporter should be pointed towards one of the [support channels](http://wp-cli.org/#support).
+* `state:unsupported` - The issue is outside of the scope of a bug report and cannot be supported on GitHub. The reporter should be pointed towards one of the [support channels](https://make.wordpress.org/cli/handbook/support/).
 
 #### Command
 

--- a/guides/beginners-guide.md
+++ b/guides/beginners-guide.md
@@ -146,6 +146,7 @@ If the built-in help isn't enough, these resources can help:
 
 - **[WP-CLI Support](https://make.wordpress.org/cli/handbook/support/)** — Search existing resources, ask a question, or report a reproducible bug.
 - **[WP-CLI Handbook](https://make.wordpress.org/cli/handbook/)** — The full reference documentation.
+- **[GitHub Issues](https://github.com/wp-cli/wp-cli/issues)** — Report bugs or search for known problems.
 - **[WordPress.org Support Forums](https://wordpress.org/support/)** — General WordPress help from the community.
 
 ## Using WP-CLI on a Remote Server (SSH)

--- a/guides/beginners-guide.md
+++ b/guides/beginners-guide.md
@@ -144,9 +144,9 @@ wp help plugin install
 
 If the built-in help isn't enough, these resources can help:
 
-- **[WP-CLI Support](https://make.wordpress.org/cli/handbook/support/)** - Search existing resources, ask a question, or report a reproducible bug.
-- **[WP-CLI Handbook](https://make.wordpress.org/cli/handbook/)** - The full reference documentation.
-- **[WordPress.org Support Forums](https://wordpress.org/support/)** - General WordPress help from the community.
+- **[WP-CLI Support](https://make.wordpress.org/cli/handbook/support/)** — Search existing resources, ask a question, or report a reproducible bug.
+- **[WP-CLI Handbook](https://make.wordpress.org/cli/handbook/)** — The full reference documentation.
+- **[WordPress.org Support Forums](https://wordpress.org/support/)** — General WordPress help from the community.
 
 ## Using WP-CLI on a Remote Server (SSH)
 

--- a/guides/beginners-guide.md
+++ b/guides/beginners-guide.md
@@ -144,9 +144,9 @@ wp help plugin install
 
 If the built-in help isn't enough, these resources can help:
 
-- **[WP-CLI Handbook](https://make.wordpress.org/cli/handbook/)** — The full reference documentation.
-- **[GitHub Issues](https://github.com/wp-cli/wp-cli/issues)** — Report bugs or search for known problems.
-- **[WordPress.org Support Forums](https://wordpress.org/support/)** — General WordPress help from the community.
+- **[WP-CLI Support](https://make.wordpress.org/cli/handbook/support/)** - Search existing resources, ask a question, or report a reproducible bug.
+- **[WP-CLI Handbook](https://make.wordpress.org/cli/handbook/)** - The full reference documentation.
+- **[WordPress.org Support Forums](https://wordpress.org/support/)** - General WordPress help from the community.
 
 ## Using WP-CLI on a Remote Server (SSH)
 

--- a/index.md
+++ b/index.md
@@ -4,6 +4,10 @@ Here are some helpful guides and resources for using WP-CLI.
 
 Can’t find what you’re looking for? [Open an issue](https://github.com/wp-cli/handbook/issues) to request improvements.
 
+## Support
+
+* **[Support](https://make.wordpress.org/cli/handbook/support/)** - Search existing resources, ask a question, or report a reproducible bug.
+
 ## Guides
 
 ### For users

--- a/support.md
+++ b/support.md
@@ -1,0 +1,22 @@
+# Support
+
+WP-CLI's maintainers and contributors have limited availability to answer
+general support questions. The current version of WP-CLI is the only officially
+supported version.
+
+Before asking for help, search for your question in these resources:
+
+* [Common issues and their fixes](https://make.wordpress.org/cli/handbook/guides/common-issues/)
+* [WP-CLI Handbook](https://make.wordpress.org/cli/handbook/)
+* [Open and closed issues in the WP-CLI GitHub organization](https://github.com/search?q=org%3Awp-cli+is%3Aissue&type=issues)
+* [Threads tagged `WP-CLI` in the WordPress.org support forums](https://wordpress.org/support/topic-tag/wp-cli/)
+* [Questions tagged `wp-cli` on WordPress Stack Exchange](https://wordpress.stackexchange.com/questions/tagged/wp-cli)
+
+If you do not find an answer in those resources:
+
+* Join the `#cli` channel in [WordPress.org Slack](https://make.wordpress.org/chat/) for quick questions and live discussion.
+* Post a new thread in the [WordPress.org support forums](https://wordpress.org/support/forums/) and tag it `wp-cli` so the community can find it.
+
+If you have found a reproducible bug in WP-CLI, please follow the
+[bug report guidelines](https://make.wordpress.org/cli/handbook/contributions/bug-reports/)
+before opening an issue.


### PR DESCRIPTION
## Summary
- Adds a central Support page for WP-CLI users
- Registers the page in the handbook manifest for WordPress.org import
- Updates stale and nearby support references to point to the new page

Related to wp-cli/scaffold-package-command#292