### PR TITLE
Document Windows argument truncation when a value contains newlines

### DIFF
--- a/guides/common-issues.md
+++ b/guides/common-issues.md
@@ -194,7 +194,7 @@ See also: [#4714](https://github.com/wp-cli/wp-cli/issues/4714)
 
 On Windows, `wp` is a `.bat` wrapper around `php wp-cli.phar`. Batch files terminate a command at a newline, including a newline inside a quoted argument, because `cmd.exe` splits the line before quoting is evaluated.
 
-Any flags positioned after the multi-line value never reach WP-CLI. The command still succeeds with the arguments it did receive, so there is no error — WordPress silently applies its defaults for the missing values. In the example below the post is created, but as a draft under Uncategorized and authored by the default user, because `--post_category`, `--post_author` and `--post_status` were all dropped:
+Any flags positioned after the multi-line value never reach WP-CLI. The command still succeeds with the arguments it did receive, so there is no error — WordPress silently applies its defaults for the missing values. In the example below the post is created, but as a draft under the site's default category and attributed to the current user, because `--post_category`, `--post_author` and `--post_status` were all dropped:
 
     wp post create --post_status=publish --post_content="<multi-line content>" --post_category=3 --post_author=2
 

--- a/guides/common-issues.md
+++ b/guides/common-issues.md
@@ -190,6 +190,26 @@ Using UTF-8 in PHP arguments doesn't work on Windows for PHP <= 7.0, however it 
 
 See also: [#4714](https://github.com/wp-cli/wp-cli/issues/4714)
 
+### Arguments containing newlines are truncated on Windows
+
+On Windows, `wp` is a `.bat` wrapper around `php wp-cli.phar`. Batch files terminate a command at a newline, including a newline inside a quoted argument, because `cmd.exe` splits the line before quoting is evaluated.
+
+Any flags positioned after the multi-line value never reach WP-CLI. The command still succeeds with the arguments it did receive, so there is no error — WordPress silently applies its defaults for the missing values. In the example below the post is created, but as a draft under Uncategorized and authored by the default user, because `--post_category`, `--post_author` and `--post_status` were all dropped:
+
+    wp post create --post_status=publish --post_content="<multi-line content>" --post_category=3 --post_author=2
+
+Pass the content over `STDIN` instead, using `-` as the positional argument. The newline then lives in the piped stream rather than in the command line, so nothing is truncated:
+
+    cat content.html | wp post create - --post_status=publish --post_category=3 --post_author=2
+
+The same applies in PowerShell:
+
+    $content | wp post create - --post_status=publish --post_category=3 --post_author=2
+
+`wp post create` and `wp post update` also accept a file path in place of `-`.
+
+See also: [#2712](https://github.com/wp-cli/wp-cli/issues/2712)
+
 ### The installation hangs
 
 If the installation seems to hang forever while trying to clone the resources from GitHub, please ensure that you are allowed to connect to Github using SSL (port 443) and Git (port 9418) for outbound connections.

--- a/guides/common-issues.md
+++ b/guides/common-issues.md
@@ -200,7 +200,7 @@ Any flags positioned after the multi-line value never reach WP-CLI. The command 
 
 Pass the content over `STDIN` instead, using `-` as the positional argument. The newline then lives in the piped stream rather than in the command line, so nothing is truncated:
 
-    cat content.html | wp post create - --post_status=publish --post_category=3 --post_author=2
+    type content.html | wp post create - --post_status=publish --post_category=3 --post_author=2
 
 The same applies in PowerShell:
 

--- a/guides/common-issues.md
+++ b/guides/common-issues.md
@@ -194,10 +194,9 @@ See also: [#4714](https://github.com/wp-cli/wp-cli/issues/4714)
 
 On Windows, `wp` is a `.bat` wrapper around `php wp-cli.phar`. Batch files terminate a command at a newline, including a newline inside a quoted argument, because `cmd.exe` splits the line before quoting is evaluated.
 
-Any flags positioned after the multi-line value never reach WP-CLI. The command still succeeds with the arguments it did receive, so there is no error — WordPress silently applies its defaults for the missing values. In the example below the post is created, but as a draft under the site's default category and attributed to the current user, because `--post_category`, `--post_author` and `--post_status` were all dropped:
+Any flags positioned after the multi-line value never reach WP-CLI. The command still succeeds with the arguments it did receive, so there is no error — WordPress silently applies its defaults for the missing values. In the example below the post is created, but as a draft under the site's default category and attributed to the current user, because everything after `--post_content` (`--post_category`, `--post_author` and `--post_status`) was dropped:
 
-    wp post create --post_status=publish --post_content="<multi-line content>" --post_category=3 --post_author=2
-
+    wp post create --post_content="<multi-line content>" --post_category=3 --post_author=2 --post_status=publish
 Pass the content over `STDIN` instead, using `-` as the positional argument. The newline then lives in the piped stream rather than in the command line, so nothing is truncated:
 
     type content.html | wp post create - --post_status=publish --post_category=3 --post_author=2


### PR DESCRIPTION
On Windows, `wp` is a .bat wrapper and cmd.exe terminates the command at a newline, including inside a quoted argument. Any flags positioned after a multi-line value are silently dropped — the command still succeeds with whatever it received, so there is no error to search for.

Reported in wp-cli/wp-cli#2712 (2016, closed as `state:unconfirmed`). The STDIN workaround was posted in a comment on that thread in 2023 but isn't documented in the handbook.

Placed next to the existing Windows/UTF-8 entry, since both are argument encoding issues with a similar STDIN-style workaround.

Reproduced on WP-CLI 2.12.0 / PHP 8.2.29 / Windows 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling Windows command-line arguments containing newlines.
  * Documented `.bat` wrapper limitations and recommended using STDIN or file paths with post creation and update commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->